### PR TITLE
Don't consider unterminated strings as complete

### DIFF
--- a/src/jsonv-tests/parse_tests.cpp
+++ b/src/jsonv-tests/parse_tests.cpp
@@ -199,6 +199,12 @@ TEST_PARSE(malformed_decimal_ignore)
     parse("123.456.789", options);
 }
 
+TEST_PARSE(malformed_string_unterminated)
+{
+    ensure_throws(jsonv::parse_error, parse(R"("abc)"));
+    ensure_throws(jsonv::parse_error, parse(R"(")"));
+}
+
 TEST_PARSE(option_complete_parse_false)
 {
     auto options = jsonv::parse_options()

--- a/src/jsonv/detail/token_patterns.cpp
+++ b/src/jsonv/detail/token_patterns.cpp
@@ -161,7 +161,7 @@ static match_result match_string(const char* begin, const char* end, token_kind&
     while (true)
     {
         if (begin + length == end)
-            return match_result::complete_eof;
+            return match_result::incomplete_eof;
         
         if (begin[length] == '\"')
         {
@@ -171,7 +171,7 @@ static match_result match_string(const char* begin, const char* end, token_kind&
         else if (begin[length] == '\\')
         {
             if (begin + length + 1 == end)
-                return match_result::complete_eof;
+                return match_result::incomplete_eof;
             else
                 length += 2;
         }


### PR DESCRIPTION
A parsed json string literal cannot be complete if the terminating quotation mark hasn't been seen yet.

`match_string()` does consider such strings as potentially complete (`match_result::complete_eof`). This causes `"\"hello"_json` to compile without errors and `"\""_json` to throw `std::range_error`. Such incomplete strings should throw `jsonv::parse_error` instead.

Returning `match_result::incomplete_eof` from `match_string` in the problematic corrects this.