### PR TITLE
OS X build adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 # File: CMakeLists used for generating a Makefile (or whatever your build system is).
 #
 # Copyright 2015 by Travis Gockel
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
@@ -160,24 +160,24 @@ if (BENCHMARK)
         list(APPEND BENCHMARK_CPPS "src/json-benchmark/${CPP_FILE}")
         list(APPEND BENCHMARK_LIBS "${LIB_NAME}")
     endmacro()
-    
+
     if (BENCHMARK_JSONV)
         add_benchmark_suite("jsonv_benchmark.cpp" "jsonv")
     endif()
-    
+
     if (BENCHMARK_JSONCPP)
         add_benchmark_suite("jsoncpp_benchmark.cpp" "jsoncpp")
         include_directories("/usr/include/jsoncpp")
     endif()
-    
+
     if (BENCHMARK_JQ)
         add_benchmark_suite("jq_benchmark.cpp" "jq")
     endif()
-    
+
     if (BENCHMARK_JANSSON)
         add_benchmark_suite("jansson_benchmark.cpp" "jansson")
     endif()
-    
+
     add_executable(json-benchmark ${BENCHMARK_CPPS})
     target_link_libraries(json-benchmark
         ${BENCHMARK_LIBS}

--- a/src/jsonv-tests/serialization_builder_tests.cpp
+++ b/src/jsonv-tests/serialization_builder_tests.cpp
@@ -33,13 +33,8 @@ struct person
     person(std::string       f,
            std::string       l,
            int               a,
-#ifdef __APPLE__
            std::set<long>    favorite_numbers = std::set<long>{},
            std::vector<long> winning_numbers  = std::vector<long>{}
-#else
-           std::set<long>    favorite_numbers = {},
-           std::vector<long> winning_numbers  = {}
-#endif
           ) :
             firstname(std::move(f)),
             lastname(std::move(l)),


### PR DESCRIPTION
Hey Travis,

As I also work on OS X, I've made some minor adjustments:

- for some reason, ``std::size_t`` and ``long`` were not properly handled by serialization
- ``std::set`` empty brace init caused compilation errors

Build is now OK and all tests pass on:

OS X Yosemite 10.10.3 (14D105g)
with
Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)

P.S.: sorry for the unnecessary dummy changes in source files, my editor strips trailing spaces.

Hope you'll find this useful.

Best,

-- 
    Rémy