### PR TITLE
fix stack overflow

### DIFF
--- a/include/jsonv/serialization.hpp
+++ b/include/jsonv/serialization.hpp
@@ -532,7 +532,7 @@ public:
     {
         try
         {
-            typename std::aligned_storage<sizeof(T), alignof(T)>::type place[sizeof(T)];
+            typename std::aligned_storage<sizeof(T), alignof(T)>::type place[1];
             T* ptr = reinterpret_cast<T*>(place);
             formats().extract(typeid(T), from, static_cast<void*>(ptr), *this);
             auto destroy = detail::on_scope_exit([ptr] { ptr->~T(); });


### PR DESCRIPTION
the size of allocated on the stack array to support T is too large , it causes stack overflow  in 
template <typename T>
T extract(const value& from) const
called recursively