### PR TITLE
Use [[fallthrough]] attribute get rid of compiler warning where supported

### DIFF
--- a/src/jsonv/algorithm_merge.cpp
+++ b/src/jsonv/algorithm_merge.cpp
@@ -13,6 +13,8 @@
 
 #include <stdexcept>
 
+#include "detail/fallthrough.hpp"
+
 namespace jsonv
 {
 
@@ -110,6 +112,7 @@ value merge_explicit(const merge_rules& rules,
             if (b.kind() == kind::integer)
                 return a.as_integer() + b.as_integer();
             // fall through to decimal handler if b is a decimal
+            JSONV_FALLTHROUGH();
         case kind::decimal:
             return a.as_decimal() + b.as_decimal();
         case kind::null:

--- a/src/jsonv/coerce.cpp
+++ b/src/jsonv/coerce.cpp
@@ -1,6 +1,6 @@
 /** \file
  *  
- *  Copyright (c) 2014-2015 by Travis Gockel. All rights reserved.
+ *  Copyright (c) 2014-2018 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
  *  as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
@@ -14,6 +14,8 @@
 #include <jsonv/util.hpp>
 
 #include <limits>
+
+#include "detail/fallthrough.hpp"
 
 namespace jsonv
 {
@@ -196,7 +198,7 @@ value coerce_merge(value a, value b)
     case kind::integer:
         if (can_coerce(b, kind::integer))
             return a.as_integer() + coerce_integer(b);
-        // fall through to see if we can coerce a decimal
+        JSONV_FALLTHROUGH();
     case kind::decimal:
         if (can_coerce(b, kind::decimal))
             return a.as_decimal() + coerce_decimal(b);

--- a/src/jsonv/detail/fallthrough.hpp
+++ b/src/jsonv/detail/fallthrough.hpp
@@ -1,0 +1,33 @@
+/** \file jsonv/detail/fallthrough.hpp
+ *
+ *  Copyright (c) 2018 by Travis Gockel. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
+ *  as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
+ *  version.
+ *
+ *  \author Travis Gockel (travis@gockelhut.com)
+**/
+#ifndef __JSONV_DETAIL_FALLTHROUGH_HPP_INCLUDED__
+#define __JSONV_DETAIL_FALLTHROUGH_HPP_INCLUDED__
+
+#include <jsonv/config.hpp>
+
+/** \def JSONV_FALLTHROUGH
+ *  Used in \c case statements that are intentionally meant to fall through to the next.
+**/
+#ifndef JSONV_FALLTHROUGH
+#   if defined __has_cpp_attribute
+#       if __has_cpp_attribute(fallthrough)
+#           define JSONV_FALLTHROUGH() [[fallthrough]]
+#       elif __has_cpp_attribute(clang::fallthrough)
+#           define JSONV_FALLTHROUGH() [[clang::fallthrough]]
+#       else
+#           define JSONV_FALLTHROUGH()
+#       endif
+#   else
+#       define JSONV_FALLTHROUGH()
+#   endif
+#endif
+
+#endif/*__JSONV_DETAIL_FALLTHROUGH_HPP_INCLUDED__*/


### PR DESCRIPTION
Issue #82.