### PR TITLE
Unicode conversion: Remove use of <codecvt> and Boost.Locale for hand…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,30 +113,9 @@ if (USE_BOOST_OPTIONAL)
     add_definitions("-DJSONV_OPTIONAL_USE_BOOST=1")
 endif()
 
-########################
-# Locale Configuration #
-########################
-
-if (CMAKE_COMPILER_IS_GNUCC)
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
-        set(USE_BOOST_LOCALE_DEFAULT ON)
-    else()
-        set(USE_BOOST_LOCALE_DEFAULT OFF)
-    endif()
-else()
-    set(USE_BOOST_LOCALE_DEFAULT OFF)
-endif()
-
-option(USE_BOOST_LOCALE
-       "Should Boost.Locale be used for character encoding conversions (as opposed to the standard library)?"
-       ${USE_BOOST_LOCALE_DEFAULT}
-      )
-if (USE_BOOST_LOCALE)
-    add_definitions("-DJSONV_CHAR_CONVERT_USE_BOOST_LOCALE=1")
-    list(APPEND REQUIRED_BOOST_LIBRARIES "locale")
-else()
-    add_definitions("-DJSONV_CHAR_CONVERT_USE_BOOST_LOCALE=0")
-endif()
+##########################
+# Coverage Configuration #
+##########################
 
 option(COVERAGE
        "Enable building with code coverage."

--- a/include/jsonv/value.hpp
+++ b/include/jsonv/value.hpp
@@ -451,9 +451,8 @@ public:
     **/
     value(const char* value);
     
-    /** Create a \c kind::string with the given \a value. Keep in mind that it will be converted to and stored as a
-     *  UTF-8 encoded string.
-    **/
+    /// Create a \c kind::string with the given \a value. Keep in mind that it will be converted to and stored as a
+    /// UTF-8 encoded string.
     value(const std::wstring& value);
     
     /** Create a \c kind::string with the given \a value. Keep in mind that it will be converted to and stored as a


### PR DESCRIPTION
…rolled code.

It would be great if this was part of C++ Standard Library.