### PR TITLE
serialization: Return previous formats instance in formats::set_global.

### DIFF
--- a/include/jsonv/serialization.hpp
+++ b/include/jsonv/serialization.hpp
@@ -313,11 +313,17 @@ public:
     **/
     static formats global();
     
-    /** Set the \c global \c formats instance. **/
-    static void set_global(formats);
+    /** Set the \c global \c formats instance.
+     *
+     *  \returns the previous value of the global formats instance.
+    **/
+    static formats set_global(formats);
     
-    /** Reset the \c global \c formats instance to \c defaults. **/
-    static void reset_global();
+    /** Reset the \c global \c formats instance to \c defaults.
+     *
+     *  \returns the previous value of the global formats instance.
+    **/
+    static formats reset_global();
     
     /** Get the coercing \c formats instance. This uses \e loose type-checking and behaves by the same rules as the
      *  \c coerce_ functions in \c coerce.hpp.

--- a/src/jsonv/serialization.cpp
+++ b/src/jsonv/serialization.cpp
@@ -481,14 +481,17 @@ formats formats::global()
     return formats::compose({ global_formats_ref() });
 }
 
-void formats::set_global(formats fmt)
+formats formats::set_global(formats fmt)
 {
-    global_formats_ref() = std::move(fmt);
+    using std::swap;
+
+    swap(global_formats_ref(), fmt);
+    return fmt;
 }
 
-void formats::reset_global()
+formats formats::reset_global()
 {
-    global_formats_ref() = default_formats_ref();
+    return set_global(default_formats_ref());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Issue #105