### PR TITLE
parse: Cast `char`s to `unsigned char`s before doing bitwise operations.

### DIFF
--- a/include/jsonv/config.hpp
+++ b/include/jsonv/config.hpp
@@ -20,7 +20,7 @@
 
 #define JSONV_VERSION_MAJOR 1
 #define JSONV_VERSION_MINOR 2
-#define JSONV_VERSION_PATCH 0
+#define JSONV_VERSION_PATCH 1
 
 /** \def JSONV_DEBUG
  *  \brief Was JSON Voorhees compiled in debug mode?


### PR DESCRIPTION
This casting should not be needed. However, GCC 8.1.0 seems to have a bug in the
optimizer that causes this function to erroneously return `true` in some cases
(specifically, `char_bitmatch('\xf0', '\xc0', '\x20')`, but not if you call the
function directly). It is possible this issue (#108) has been misdiagnosed, but
the behavior only happens on GCC 8.1.0 and only with -O3. The casting also fixes
the problem, even though it logically should not change anything
(https://stackoverflow.com/questions/50671485/bitwise-operations-on-signed-chars).

Will continue investigating potential GCC regressions, but this is probably okay
for now.

- Issue #108 (probably fixed)