### PR TITLE
Stateless

### DIFF
--- a/src/jsonv-tests/serialization_builder_tests.cpp
+++ b/src/jsonv-tests/serialization_builder_tests.cpp
@@ -631,4 +631,49 @@ TEST(serialization_builder_polymorphic_direct)
     ensure_eq(input, encoded);
 }
 
+TEST(serialization_builder_duplicate_type_actions)
+{
+    struct sometype
+    {
+        int64_t v;
+    };
+
+    // Make one adapter that serializes and deserializes an int directly.
+    static const auto adapter1 = make_adapter(
+        [](const extraction_context&, const value& v) { return sometype{v.as_integer()}; },
+        [](const serialization_context&, const sometype& v) { return value(v.v); });
+
+    // Make another adapter that adds one each time an int is serialized and deserialized.
+    static const auto adapter2 = make_adapter(
+        [](const extraction_context&, const value& v) { return sometype{v.as_integer() + 1}; },
+        [](const serialization_context&, const sometype& v) { return value(v.v + 1); });
+
+    // Helper that serializes then deserializes an integer and returns the result.
+    static const auto serde = [] (int v, const formats& f) { return extract<sometype>(to_json(sometype{v}, f), f).v; };
+
+    // Initial adapter registration.
+    formats_builder builder;
+    builder.register_adapter(&adapter1);
+    ensure_eq(1, serde(1, builder));
+
+    // Default should throw, and the adapter should be unchanged.
+    ensure_throws(duplicate_type_error, builder.register_adapter(&adapter2));
+    ensure_eq(1, serde(1, builder));
+
+    // Ignore should not throw, but the adapter should still be unchanged.
+    builder.on_duplicate_type(duplicate_type_action::ignore);
+    builder.register_adapter(&adapter2);
+    ensure_eq(1, serde(1, builder));
+
+    // Replace should not throw, and the adapter should be replaced.
+    builder.on_duplicate_type(duplicate_type_action::replace);
+    builder.register_adapter(&adapter2);
+    ensure_eq(3, serde(1, builder));
+
+    // Going back to exception should again throw an exception.
+    builder.on_duplicate_type(duplicate_type_action::exception);
+    ensure_throws(duplicate_type_error, builder.register_adapter(&adapter1));
+    ensure_eq(3, serde(1, builder));
+}
+
 }

--- a/src/jsonv/serialization_builder.cpp
+++ b/src/jsonv/serialization_builder.cpp
@@ -86,6 +86,12 @@ formats_builder& formats_builder::check_references(formats other, const std::str
     }
 }
 
+formats_builder& formats_builder::on_duplicate_type(duplicate_type_action action) noexcept
+{
+    _duplicate_type_action = action;
+    return *this;
+}
+
 namespace detail
 {
 
@@ -117,6 +123,11 @@ formats_builder& formats_builder_dsl::register_adapter(std::shared_ptr<const ada
 formats_builder& formats_builder_dsl::check_references(formats other, const std::string& name)
 {
     return owner->check_references(other, name);
+}
+
+formats_builder& formats_builder_dsl::on_duplicate_type(duplicate_type_action action) noexcept
+{
+    return owner->on_duplicate_type(action);
 }
 
 }


### PR DESCRIPTION
This should resolve #106. It adds an `on_duplicate_type` function to `formats_builder` which takes a `duplicate_type_action` as a parameter. The `formats` object functions `register_extractor`, `register_serializer`, and `register_adapter` were also updated to accept a `duplicate_type_action`. The valid actions are:

* `duplicate_type_action::ignore` -- Ignores any duplicate types, and does not change the existing serializers and extractors.
* `duplicate_type_action::replace` -- Ignores any duplicate types, and replaces the existing serializer or extractor.
* `duplicate_type_action::exception` -- Throws an exception. A new `duplicate_type_error` exception was created to distinguish this type of error from other errors.

A unit test was added to test this functionality, and the serialization builder DSL documentation was updated with the new interface.