### PR TITLE
Add option to ignore or replace duplicate adapter registrations.

### DIFF
--- a/src/jsonv/serialization_builder.cpp
+++ b/src/jsonv/serialization_builder.cpp
@@ -86,6 +86,12 @@ formats_builder& formats_builder::check_references(formats other, const std::str
     }
 }
 
+formats_builder& formats_builder::on_duplicate_type(duplicate_type_action action) noexcept
+{
+    _duplicate_type_action = action;
+    return *this;
+}
+
 namespace detail
 {
 
@@ -117,6 +123,11 @@ formats_builder& formats_builder_dsl::register_adapter(std::shared_ptr<const ada
 formats_builder& formats_builder_dsl::check_references(formats other, const std::string& name)
 {
     return owner->check_references(other, name);
+}
+
+formats_builder& formats_builder_dsl::on_duplicate_type(duplicate_type_action action) noexcept
+{
+    return owner->on_duplicate_type(action);
 }
 
 }


### PR DESCRIPTION
This should resolve #106. It adds an `on_duplicate_type` function to `formats_builder` which takes a `duplicate_type_action` as a parameter. The `formats` object functions `register_extractor`, `register_serializer`, and `register_adapter` were also updated to accept a `duplicate_type_action`. The valid actions are:

* `duplicate_type_action::ignore` -- Ignores any duplicate types, and does not change the existing serializers and extractors.
* `duplicate_type_action::replace` -- Ignores any duplicate types, and replaces the existing serializer or extractor.
* `duplicate_type_action::exception` -- Throws an exception. A new `duplicate_type_error` exception was created to distinguish this type of error from other errors.

A unit test was added to test this functionality, and the serialization builder DSL documentation was updated with the new interface.