### PR TITLE
Modified check_type(...) to add "but found <type>"

### DIFF
--- a/include/jsonv/value.hpp
+++ b/include/jsonv/value.hpp
@@ -929,16 +929,17 @@ public:
     object_node_handle extract(const std::wstring& key);
     /// \}
 
-    /** Is the underlying structure empty? This has similar meaning for all types it works on and is always equivalent
-     *  to asking if the size is 0.
+    /** Is the underlying structure empty?
      *  
      *   - object: Are there no keys?
      *   - array: Are there no values?
      *   - string: Is the string 0 length?
+     *   - null: true (always)
+     *   - all other types: false (always)
      *  
-     *  \throws kind_error if the kind is not an object, array or string.
+     *  \throws nothing
     **/
-    bool empty() const;
+    bool empty() const noexcept;
     
     /** Get the number of items in this value.
      *  

--- a/src/jsonv/detail.cpp
+++ b/src/jsonv/detail.cpp
@@ -88,6 +88,7 @@ void check_type(std::initializer_list<kind> expected, kind actual)
                 stream << " or ";
             ++num;
         }
+        stream << " but found " << kind_desc(actual) << ".";
         throw kind_error(stream.str());
     }
 }

--- a/src/jsonv/value.cpp
+++ b/src/jsonv/value.cpp
@@ -516,7 +516,7 @@ bool value::empty() const
 
 value::size_type value::size() const
 {
-    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string, jsonv::kind::null }, kind());
+    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string }, kind());
     
     switch (kind())
     {
@@ -526,11 +526,10 @@ value::size_type value::size() const
         return _data.array->size();
     case jsonv::kind::string:
         return _data.string->_string.size();
-    case jsonv::kind::null:
-        return 0; // by definition a null value has zero size
     case jsonv::kind::integer:
     case jsonv::kind::decimal:
     case jsonv::kind::boolean:
+    case jsonv::kind::null:
     default:
         // Should never hit this...
         return false;

--- a/src/jsonv/value.cpp
+++ b/src/jsonv/value.cpp
@@ -491,10 +491,8 @@ std::string to_string(const value& val)
     return os.str();
 }
 
-bool value::empty() const
+bool value::empty() const noexcept
 {
-    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string, jsonv::kind::null }, kind());
-    
     switch (kind())
     {
     case jsonv::kind::object:
@@ -508,9 +506,10 @@ bool value::empty() const
     case jsonv::kind::integer:
     case jsonv::kind::decimal:
     case jsonv::kind::boolean:
+        return false; // in the sense that they contain a value
     default:
         // Should never hit this...
-        return false;
+        return true;
     }
 }
 
@@ -532,7 +531,7 @@ value::size_type value::size() const
     case jsonv::kind::null:
     default:
         // Should never hit this...
-        return false;
+        return 0;
     }
 }
 

--- a/src/jsonv/value.cpp
+++ b/src/jsonv/value.cpp
@@ -493,7 +493,7 @@ std::string to_string(const value& val)
 
 bool value::empty() const
 {
-    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string }, kind());
+    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string, jsonv::kind::null }, kind());
     
     switch (kind())
     {
@@ -503,10 +503,11 @@ bool value::empty() const
         return _data.array->empty();
     case jsonv::kind::string:
         return _data.string->_string.empty();
+    case jsonv::kind::null:
+        return true; // by definition a null value is empty
     case jsonv::kind::integer:
     case jsonv::kind::decimal:
     case jsonv::kind::boolean:
-    case jsonv::kind::null:
     default:
         // Should never hit this...
         return false;
@@ -515,7 +516,7 @@ bool value::empty() const
 
 value::size_type value::size() const
 {
-    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string }, kind());
+    check_type({ jsonv::kind::object, jsonv::kind::array, jsonv::kind::string, jsonv::kind::null }, kind());
     
     switch (kind())
     {
@@ -525,10 +526,11 @@ value::size_type value::size() const
         return _data.array->size();
     case jsonv::kind::string:
         return _data.string->_string.size();
+    case jsonv::kind::null:
+        return 0; // by definition a null value has zero size
     case jsonv::kind::integer:
     case jsonv::kind::decimal:
     case jsonv::kind::boolean:
-    case jsonv::kind::null:
     default:
         // Should never hit this...
         return false;


### PR DESCRIPTION
The overload for a single type adds "but found <type>"  the end of the string, but the overload for multiple types does not. Now it does.