### PR TITLE
serialization: Throw an `extraction_error` on missing keys.

### DIFF
--- a/include/jsonv/serialization_builder.hpp
+++ b/include/jsonv/serialization_builder.hpp
@@ -1,7 +1,7 @@
 /** \file jsonv/serialization_builder.hpp
  *  DSL for building \c formats.
- *  
- *  Copyright (c) 2015-2016 by Travis Gockel. All rights reserved.
+ *
+ *  Copyright (c) 2015-2019 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
  *  as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
@@ -26,14 +26,14 @@ namespace jsonv
 {
 
 /** \page serialization_builder_dsl Serialization Builder DSL
- *  
+ *
  *  Most applications tend to have a lot of structure types. While it is possible to write an \c extractor and
  *  \c serializer (or \c adapter) for each type, this can get a little bit tedious. Beyond that, it is very difficult to
  *  look at the contents of adapter code and discover what the JSON might actually look like. The builder DSL is meant
  *  to solve these issues by providing a convenient way to describe conversion operations for your C++ types.
- *  
+ *
  *  At the end of the day, the goal is to take some C++ structures like this:
- *  
+ *
  *  \code
  *  struct person
  *  {
@@ -42,7 +42,7 @@ namespace jsonv
  *      int         age;
  *      std::string role;
  *  };
- *  
+ *
  *  struct company
  *  {
  *      std::string         name;
@@ -51,9 +51,9 @@ namespace jsonv
  *      std::list<person>   candidates;
  *  };
  *  \endcode
- *  
+ *
  *  ...and easily convert it to an from a JSON representation that looks like this:
- *  
+ *
  *  \code
  *  {
  *      "name": "Paul's Construction",
@@ -79,9 +79,9 @@ namespace jsonv
  *      ]
  *  }
  *  \endcode
- *  
+ *
  *  To define a \c formats for this \c person type using the serialization builder DSL, you would say:
- *  
+ *
  *  \code
  *  jsonv::formats fmts =
  *      jsonv::formats_builder()
@@ -107,26 +107,26 @@ namespace jsonv
  *          .check_references(jsonv::formats::defaults())
  *      ;
  *  \endcode
- * 
+ *
  *  \section Reference
- *  
+ *
  *  The DSL is made up of three major parts:
- *  
+ *
  *   1. \e formats -- modifies a \c jsonv::formats object by adding new type adapters to it
  *   2. \e type -- modifies the behavior of a \c jsonv::adapter by adding new members to it
  *   3. \e member -- modifies an individual member inside of a specific type
- *  
+ *
  *  Each successive function call transforms your context. \e Narrowing calls make your context more specific; for
  *  example, calling \c type from a \e formats context allows you to modify a specific type. \e Widening calls make the
  *  context less specific and are always available; for example, when in the \e member context, you can still call
  *  \c type from the \e formats context to specify a new type.
- *  
+ *
  *  \dot
  *  digraph serialization_builder_dsl {
  *    formats  [label="formats"]
  *    type     [label="type"]
  *    member   [label="member"]
- *    
+ *
  *    formats -> formats
  *    formats -> type
  *    type    -> formats
@@ -137,73 +137,73 @@ namespace jsonv
  *    member  -> member
  *  }
  *  \enddot
- *  
+ *
  *  \subsection serialization_builder_dsl_ref_formats Formats Context
- *  
+ *
  *  Commands in this section modify the behavior of the underlying \c jsonv::formats object.
- *  
+ *
  *  \subsubsection serialization_builder_dsl_ref_formats_level Level
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_check_references check_references
- *  
+ *
  *   - <tt>check_references(formats)</tt>
  *   - <tt>check_references(formats, std::string name)</tt>
  *   - <tt>check_references(formats::list)</tt>
  *   - <tt>check_references(formats::list, std::string name)</tt>
  *   - <tt>check_references()</tt>
  *   - <tt>check_references(std::string name)</tt>
- *  
+ *
  *  Tests that every type referenced by the members of the output of the DSL have an \c extractor and a \c serializer.
  *  The provided \c formats is used to draw extra types from (a common value is \c jsonv::formats::defaults). In other
  *  words, it asks the question: If the \c formats from this DSL was combined with these other \c formats, could all of
  *  the types be encoded and decoded?
- *  
+ *
  *  This does not mutate the DSL in any way. On successful verification, it will appear that nothing happened. If the
  *  verification is not successful, an exception will be thrown with the offending types in the message. For example:
- *  
+ *
  *  \code
- *  There are 2 types referenced that the formats do not know how to serialize: 
+ *  There are 2 types referenced that the formats do not know how to serialize:
  *   - date_type (referenced by: name_space::foo, other::name::space::bar)
  *   - tree
  *  \endcode
- *  
+ *
  *  If \a name is provided, the value will be output to the error message on failure. This can be useful if you have
  *  multiple \c check_references statements and wish to more easily determine the failing \c formats combination from
  *  the error message alone.
- *  
+ *
  *  \note
  *  This is evaluated \e immediately, so it is best to call this function as the very last step in the DSL.
- *  
+ *
  *  \code
  *    .check_references(jsonv::formats::defaults())
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_reference_type reference_type
- *  
+ *
  *   - <tt>reference_type(std::type_index type)</tt>
  *   - <tt>reference_type(std::type_index type, std::type_index from)</tt>
- *  
+ *
  *  Explicitly add a reference to the provided \a type in the DSL. If \a from is provided, also add a back reference for
  *  tracking purposes. The \a from field is useful for tracking \e why the \a type is referenced.
- *  
+ *
  *  Type references are used in \ref serialization_builder_dsl_ref_formats_level_check_references to both check and
  *  generate error messages if the \c formats the DSL is building cannot fully create and extract JSON values. You do
  *  not usually have to call this, as each call to \ref serialization_builder_dsl_ref_type_narrowing_member calls this
  *  automatically.
- *  
+ *
  *  \code
  *    .reference_type(std::type_index(typeid(int)), std::type_index(typeid(my_type)))
  *    .reference_type(std::type_index(typeid(my_type))
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_register_adapter register_adapter
- *  
+ *
  *   - <tt>register_adapter(const adapter*)</tt>
  *   - <tt>register_adapter(std::shared_ptr&lt;const adapter&gt;)</tt>
- *  
+ *
  *  Register an arbitrary \c adapter with the \c formats we are currently building. This is useful for integrating with
  *  type adapters that do not (or can not) use the DSL.
- *  
+ *
  *  \code
  *    .register_adapter(my_type::get_adapter())
  *  \endcode
@@ -220,30 +220,30 @@ namespace jsonv
  *  \endcode
  *
  *  \paragraph serialization_builder_dsl_ref_formats_level_register_container register_container
- *  
+ *
  *   - <tt>register_container&lt;TContainer&gt;()</tt>
- *  
+ *
  *  Similar to \c register_adapter, but automatically create a <tt>container_adapter&lt;TContainer&gt;</tt> to store.
- *  
+ *
  *  \code
  *    .register_container<std::vector<int>>()
  *    .register_container<std::list<std::string>>()
  *  \endcode
- * 
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_register_containers register_containers
- *  
+ *
  *   - <tt>register_containers&lt;T, template &lt;T, ...&gt;... TTContainer&gt;</tt>
- *  
+ *
  *  Convenience function for calling \c register_container for multiple containers with the same \c value_type.
  *  Unfortunately, it only supports varying the first template parameter of the \c TTContainer types, so if you wish to
  *  do something like vary the allocator, you will have to either call \c register_container multiple times or use a
  *  template alias.
- *  
+ *
  *  \code
  *    .register_containers<int, std::list, std::deque>()
  *    .register_containers<double, std::vector, std::set>()
  *  \endcode
- *  
+ *
  *  \note
  *  Not supported in MSVC 14 (CTP 5).
  *
@@ -257,20 +257,20 @@ namespace jsonv
  *    .register_optional<std::optional<int>>()
  *    .register_optional<boost::optional<double>>()
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_enum_type enum_type
- *  
+ *
  *   - <tt>enum_type&lt;TEnum&gt;(std::string name, std::initializer_list&lt;std::pair&lt;TEnum, jsonv::value&gt;&gt;)</tt>
  *   - <tt>enum_type_icase&lt;TEnum&gt;(std::string name, std::initializer_list&lt;std::pair&lt;TEnum, jsonv::value&gt;&gt;)</tt>
- *  
+ *
  *  Create an adapter for the \c TEnum type with a mapping of C++ values to JSON values and vice versa. The most common
  *  use of this is to map \c enum values in C++ to string representations in JSON. \c TEnum is not restricted to types
  *  which are \c enum, but can be anything which you would like to restrict to a limited subset of possible values.
  *  Likewise, JSON representations are not restricted to being of \c kind::string.
- *  
+ *
  *  The sibling function \c enum_type_icase will create an adapter which uses case-insensitive checking when converting
  *  to C++ values in \c extract.
- *  
+ *
  *  \code
  *    .enum_type<ring>("ring",
  *                     {
@@ -294,9 +294,9 @@ namespace jsonv
  *                          }
  *                         )
  *  \endcode
- *  
+ *
  *  \see enum_adapter
- *  
+ *
  *  \paragraph serialization_builder_dls_ref_formats_level_polymorphic_type polymorphic_type
  *
  *  - <tt>polymorphic_type<&lt;TPointer&gt;(std::string discrimination_key);</tt>
@@ -319,19 +319,19 @@ namespace jsonv
  *  nothing (\ref keyed_subtype_action::none).
  *
  *  \paragraph serialization_builder_dsl_ref_formats_level_extend extend
- *  
+ *
  *   - <tt>extend(std::function&lt;void (formats_builder&amp;)&gt; func)</tt>
- *  
+ *
  *  Extend the \c formats_builder with the provided \a func by passing the current builder to it. This provides a more
  *  convenient way to call helper functions.
- *  
+ *
  *  \code
  *  jsonv::formats_builder builder;
  *  foo(builder);
  *  bar(builder);
  *  baz(builder);
  *  \endcode
- *  
+ *
  *  This can be done equivalently with:
  *  \code
  *  jsonv::formats_builder()
@@ -339,7 +339,7 @@ namespace jsonv
  *    .extend(bar)
  *    .extend(baz)
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_level_on_duplicate_type on_duplicate_type
  *
  *    - <tt>on_duplicate_type(on_duplicate_type_action action);</tt>
@@ -349,18 +349,18 @@ namespace jsonv
  *  the \c formats_builder can also be configured to ignore the duplicate (\ref duplicate_type_action::ignore), or to
  *  replace the existing adapter with the new one (\ref duplicate_type_action::replace). This is useful when calling
  *  multiple \c extend methods that may add common types to the \c formats_builder.
- *  
+ *
  *  \subsubsection serialization_builder_dsl_ref_formats_narrowing Narrowing
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_formats_narrowing_type type&lt;T&gt;
- *  
+ *
  *   - <tt>type&lt;T&gt;()</tt>
  *   - <tt>type&lt;T&gt;(std::function&lt;void (adapter_builder&lt;T&gt;&amp;)&gt; func)</tt>
- *  
+ *
  *  Create an \c adapter for type \c T and begin building the members for it. If \a func is provided, it will be called
  *  with the adapter_builder&lt;T&gt; this call to \c type creates, which can be used for creating common extension
  *  functions.
- *  
+ *
  *  \code
  *    .type<my_type>()
  *        .member(...)
@@ -368,60 +368,60 @@ namespace jsonv
  *        .
  *        .
  *  \endcode
- *  
- *  
+ *
+ *
  *  \subsection serialization_builder_dsl_ref_type Type Context
- *  
+ *
  *  Commands in this section modify the behavior of the \c jsonv::adapter for a particular type.
- *  
+ *
  *  \subsubsection serialization_builder_dsl_ref_type_level Level
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_type_level_pre_extract pre_extract
- *  
+ *
  *   - <tt>pre_extract(std::function&lt;void (const extraction_context& context, const value& from)&gt; perform)</tt>
- *  
+ *
  *  Call the given \a perform function during the \c extract operation, but before performing any extraction. This can
  *  be called multiple times -- all functions will be called in the order they are provided.
  *
  *  \paragraph serialization_builder_dsl_ref_type_level_post_extract post_extract
- *  
+ *
  *   - <tt>post_extract(std::function&lt;T (const extraction_context& context, T&& out)&gt; perform)</tt>
- *  
+ *
  *  Call the given \a perform function after the \c extract operation. All functions will be called in the order they
  *  are provided. This allows validation methods to be called on the extracted object as part of extraction.
  *  Postprocessing functions are allowed to mutate the extracted object.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_type_level_default_on_null type_default_on_null
- *  
+ *
  *   - <tt>type_default_on_null()</tt>
  *   - <tt>type_default_on_null(bool on)</tt>
- *  
+ *
  *  If the JSON value \c null is in the input, should this type take on some default?
  *  This should be used with \ref serialization_builder_dsl_ref_type_level_type_default_value type_default_value.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_type_level_type_default_value
- *  
+ *
  *   - <tt>type_default_value(T value)</tt>
  *   - <tt>type_default_value(std::function&lt;T (const extraction_context& context)&gt;)</tt>
- *  
+ *
  *  What value should be used to create the default for this type?
- *  
+ *
  *  \code
  *    .type<my_type>()
  *        .type_default_on_null()
  *        .type_default_value(my_type("default"))
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_type_level_on_extract_extra_keys on_extract_extra_keys
- *  
+ *
  *   - <tt>on_extract_extra_keys(std::function&lt;void (const extraction_context&   context,
  *                                                      const value&                from,
  *                                                      std::set&lt;std::string&gt; extra_keys)&gt; action
  *                              )</tt>
- *  
+ *
  *  When extracting, perform some \a action if extra keys are provided. By default, extra keys are usually simply
  *  ignored, so this is useful if you wish to throw an exception (or anything you want).
- *  
+ *
  *  \code
  *    .type<my_type>()
  *        .member("x", &my_type::x)
@@ -432,121 +432,121 @@ namespace jsonv
  *                               }
  *                              )
  *  \endcode
- *  
+ *
  *  There is a convenience function named \c throw_extra_keys_extraction_error which does this for you.
- *  
+ *
  *  \code
  *    .type<my_type>()
  *        .member("x", &my_type::x)
  *        .member("y", &my_type::y)
  *        .on_extract_extra_keys(jsonv::throw_extra_keys_extraction_error)
  *  \endcode
- *  
+ *
  *  \subsubsection serialization_builder_dsl_ref_type_narrowing Narrowing
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_type_narrowing_member member
- *  
+ *
  *   - <tt>member(std::string name, TMember T::*selector)</tt>
  *   - <tt>member(std::string name, const TMember& (*access)(const T&), void (*mutate)(T&, TMember&&))</tt>
  *   - <tt>member(std::string name, const TMember& (T::*access)() const, TMember& (T::*mutable_access)())</tt>
  *   - <tt>member(std::string name, const TMember& (T::*access)() const, void (T::*mutate)(TMember))</tt>
  *   - <tt>member(std::string name, const TMember& (T::*access)() const, void (T::*mutate)(TMember&&))</tt>
- *  
+ *
  *  Adds a member to the type we are currently building. By default, the member will be serialized with the key of the
  *  given \a name and the extractor will search for the given \a name. If you wish to change properties of this field,
  *  use the \ref serialization_builder_dsl_ref_member.
- *  
+ *
  *  \code
  *    .type<my_type>()
  *        .member("x", &my_type::x)
  *        .member("y", &my_type::y)
  *        .member("thing", &my_type::get_thing, &my_type::set_thing)
  *  \endcode
- *  
- *  
+ *
+ *
  *  \subsection serialization_builder_dsl_ref_member Member Context
- *  
+ *
  *  Commands in this section modify the behavior of a particular member. Here, \c T refers to the containing type (the
  *  one we are adding a member to) and \c TMember refers to the type of the member we are modifying.
- *  
+ *
  *  \subsubsection serialization_builder_dsl_ref_member_level Level
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_after after
- *  
+ *
  *   - <tt>after(version)</tt>
- *  
+ *
  *  Only serialize this member if the \c serialization_context::version is not \c version::empty and is greater than or
  *  equal to the provided \c version.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_alternate_name alternate_name
- *  
+ *
  *   - <tt>alternate_name(std::string name)</tt>
- *  
+ *
  *  Provide an alternate name to search for when extracting this member. If a user provides values for multiple names,
  *  preference is given to names earlier in the list, starting with the original given name.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_before before
- *  
+ *
  *   - <tt>before(version)</tt>
- *  
+ *
  *  Only serialize this member if the \c serialization_context::version is not \c version::empty and is less than or
  *  equal to the provided \c version.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_check_input check_input
- *  
+ *
  *   - <tt>check_input(std::function&lt;void (const TMember&)&gt; check)</tt>
  *   - <tt>check_input(std::function&lt;bool (const TMember&)&gt; check, std::function&lt;void (const TMember&)&gt; thrower)</tt>
  *   - <tt>check_input(std::function&lt;bool (const TMember&)&gt; check, TException ex)</tt>
- *  
+ *
  *  Checks the extracted value with the given \a check function. In the first form, you are expected to throw inside the
  *  function. In the latter forms, the second parameter will be invoked (in the case of \a thrower) or thrown directly
  *  (in the case of \a ex).
- *  
+ *
  *  \code
  *    .member("x", &my_type::x)
  *        .check_input([] (int x) { if (x < 0) throw std::logic_error("x must be greater than 0"); })
  *        .check_input([] (int x) { return x < 100; }, [] (int x) { throw exceptions::less_than(100, x); })
  *        .check_input([] (int x) { return x % 2 == 0; }, std::logic_error("x must be divisible by 2"))
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_default_value default_value
- *  
+ *
  *   - <tt>default_value(TMember value)</tt>
  *   - <tt>default_value(std::function&lt;TMember (const extraction_context&, const value&)&gt; create)</tt>
- *  
+ *
  *  Provide a default value for this member if no key is found when extracting. You can use the function implementation
  *  to synthesize the key however you want.
- *  
+ *
  *  \code
  *   .member("x", &my_type::x)
  *       .default_value(10)
  *  \endcode
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_default_on_null default_on_null
- *  
+ *
  *   - <tt>default_on_null()</tt>
  *   - <tt>default_on_null(bool on)</tt>
- *  
+ *
  *  If the value associated with this key is \c kind::null, should that be treated as the default value? This option is
  *  only considered if a \ref serialization_builder_dsl_ref_member_level_default_value default_value was provided.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_encode_if encode_if
- *  
+ *
  *   - <tt>encode_if(std::function&lt;bool (const serialization_context&, const TMember&amp;)&gt; check)</tt>
- *  
+ *
  *  Only serialize this member if the \a check function returns true.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_since since
- *  
+ *
  *   - <tt>since(version)</tt>
- *  
+ *
  *  Only serialize this member if the \c serialization_context::version is not \c version::empty and is greater than the
  *  provided \c version.
- *  
+ *
  *  \paragraph serialization_builder_dsl_ref_member_level_until until
- *  
+ *
  *   - <tt>until(version)</tt>
- *  
+ *
  *  Only serialize this member if the \c serialization_context::version is not \c version::empty and is less than the
  *  provided \c version.
 **/
@@ -566,34 +566,34 @@ public:
     explicit formats_builder_dsl(formats_builder* owner) :
             owner(owner)
     { }
-    
+
     template <typename T>
     adapter_builder<T> type();
-    
+
     template <typename T, typename F>
     adapter_builder<T> type(F&&);
-    
+
     template <typename TEnum>
     formats_builder& enum_type(std::string enum_name, std::initializer_list<std::pair<TEnum, value>> mapping);
-    
+
     template <typename TEnum>
     formats_builder& enum_type_icase(std::string enum_name, std::initializer_list<std::pair<TEnum, value>> mapping);
-    
+
     template <typename TPointer>
     polymorphic_adapter_builder<TPointer> polymorphic_type(std::string discrimination_key = "");
-    
+
     template <typename TPointer, typename F>
     polymorphic_adapter_builder<TPointer> polymorphic_type(std::string discrimination_key, F&&);
-    
+
     template <typename F>
     formats_builder& extend(F&&);
-    
+
     formats_builder& register_adapter(const adapter* p);
     formats_builder& register_adapter(std::shared_ptr<const adapter> p);
-    
+
     formats_builder& reference_type(std::type_index typ);
     formats_builder& reference_type(std::type_index type, std::type_index from);
-    
+
     template <typename TOptional>
     formats_builder& register_optional();
 
@@ -616,9 +616,9 @@ public:
 
     formats compose_checked(formats other, const std::string& name = "");
     formats compose_checked(std::vector<formats> others, const std::string& name = "");
-    
+
     operator formats() const;
-    
+
 protected:
     formats_builder* owner;
 };
@@ -630,13 +630,13 @@ public:
     explicit adapter_builder_dsl(adapter_builder<T>* owner) :
             owner(owner)
     { }
-    
+
     adapter_builder<T>& type_default_on_null(bool on = true);
-    
+
     adapter_builder<T>& type_default_value(std::function<T (const extraction_context& ctx)> create);
 
     adapter_builder<T>& type_default_value(const T& value);
-    
+
     template <typename TMember>
     member_adapter_builder<T, TMember> member(std::string name, TMember T::*selector);
 
@@ -663,13 +663,13 @@ public:
                                               const TMember& (T::*access)() const,
                                               void (T::*mutate)(TMember&&)
                                              );
-    
+
     adapter_builder<T>& pre_extract(typename adapter_builder<T>::pre_extract_func perform);
 
     adapter_builder<T>& post_extract(typename adapter_builder<T>::post_extract_func perform);
 
     adapter_builder<T>& on_extract_extra_keys(typename adapter_builder<T>::extra_keys_func handler);
-    
+
 protected:
     adapter_builder<T>* owner;
 };
@@ -680,11 +680,11 @@ class member_adapter
 public:
     virtual ~member_adapter() noexcept
     { }
-    
+
     virtual void mutate(const extraction_context& context, const value& from, T& out) const = 0;
-    
+
     virtual void to_json(const serialization_context& context, const T& from, value& out) const = 0;
-    
+
     virtual bool has_extract_key(string_view key) const = 0;
 };
 
@@ -709,43 +709,43 @@ public:
                                 [selector] (const T& value) -> const TMember& { return value.*selector; }
                                )
     { }
-    
+
     virtual void mutate(const extraction_context& context, const value& from, T& out) const override
     {
         value::const_object_iterator iter;
         for (const auto& name : _names)
             if ((iter = from.find(name)) != from.end_object())
                 break;
-        
+
         bool use_default = false;
         if (iter == from.end_object())
         {
             use_default = bool(_default_value);
             if (!use_default)
-                return;
+                throw extraction_error(context, std::string("Missing required field ") + _names.at(0));
         }
         else if (_default_on_null && iter->second.kind() == kind::null)
         {
             use_default = true;
         }
-        
+
         if (use_default)
             _set_value(out, _default_value(context, from));
         else
             _set_value(out, context.extract_sub<TMember>(from, iter->first));
     }
-    
+
     virtual void to_json(const serialization_context& context, const T& from, value& out) const override
     {
         if (should_encode(context, from))
             out.insert({ _names.at(0), context.to_json(_get_value(from)) });
     }
-    
+
     virtual bool has_extract_key(string_view key) const override
     {
         return std::any_of(begin(_names), end(_names), [key] (const std::string& name) { return name == key; });
     }
-    
+
     void add_encode_check(std::function<bool (const serialization_context&, const TMember&)> check)
     {
         if (_should_encode)
@@ -761,7 +761,7 @@ public:
             _should_encode = std::move(check);
         }
     }
-    
+
     void add_extraction_mutator(std::function <TMember (TMember&&)> mutate)
     {
         if (_extract_mutate)
@@ -774,7 +774,7 @@ public:
             _extract_mutate = std::move(mutate);
         }
     }
-    
+
     void add_extraction_check(std::function <void (const TMember&)> check)
     {
         add_extraction_mutator([check] (TMember&& value)
@@ -783,17 +783,17 @@ public:
             return value;
         });
     }
-    
+
     void default_value(std::function<TMember (const extraction_context&, const value&)>&& create)
     {
         _default_value = std::move(create);
     }
-    
+
     void default_on_null(bool on)
     {
         _default_on_null = on;
     }
-    
+
 private:
     bool should_encode(const serialization_context& context, const T& from) const
     {
@@ -802,11 +802,11 @@ private:
         else
             return true;
     }
-    
+
 private:
     template <typename U, typename UMember>
     friend class member_adapter_builder;
-    
+
 private:
     std::vector<std::string>                                           _names;
     mutator_type                                                       _set_value;
@@ -835,20 +835,20 @@ public:
     {
         reference_type(std::type_index(typeid(TMember)), std::type_index(typeid(T)));
     }
-    
+
     /** When extracting, also look for this \a name as a key. **/
     member_adapter_builder& alternate_name(std::string name)
     {
         _adapter->_names.emplace_back(std::move(name));
         return *this;
     }
-    
+
     member_adapter_builder& check_input(std::function<void (const TMember&)> check)
     {
         _adapter->add_extraction_check(std::move(check));
         return *this;
     }
-    
+
     member_adapter_builder& check_input(std::function<bool (const TMember&)> check,
                                         std::function<void (const TMember&)> thrower
                                        )
@@ -860,13 +860,13 @@ public:
             });
         return *this;
     }
-    
+
     template <typename TException>
     member_adapter_builder& check_input(std::function<void (const TMember&)> check, const TException& ex)
     {
         return check_input(std::move(check), [ex] (const TMember&) { throw ex; });
     }
-    
+
     /** If the key for this member is not in the object when deserializing, call this function to create a value. If a
      *  \c default_value is not specified, the key is required.
     **/
@@ -875,7 +875,7 @@ public:
         _adapter->default_value(std::move(create));
         return *this;
     }
-    
+
     /** If the key for this member is not in the object when deserializing, use this \a value. If a \c default_value is
      *  not specified, the key is required.
     **/
@@ -883,14 +883,14 @@ public:
     {
         return default_value([value] (const extraction_context&, const jsonv::value&) { return value; });
     }
-    
+
     /** Should a \c kind::null for a key be interpreted as a missing value? **/
     member_adapter_builder& default_on_null(bool on = true)
     {
         _adapter->default_on_null(on);
         return *this;
     }
-    
+
     /** Only encode this member if the \a check passes. The final decision to encode is based on \e all \c check
      *  functions.
     **/
@@ -899,7 +899,7 @@ public:
         _adapter->add_encode_check(std::move(check));
         return *this;
     }
-    
+
     /** Only encode this member if the \c serialization_context::version is greater than or equal to \a ver. **/
     member_adapter_builder& since(version ver)
     {
@@ -909,7 +909,7 @@ public:
                          }
                         );
     }
-    
+
     /** Only encode this member if the \c serialization_context::version is less than or equal to \a ver. **/
     member_adapter_builder& until(version ver)
     {
@@ -919,7 +919,7 @@ public:
                          }
                         );
     }
-    
+
     /** Only encode this member if the \c serialization_context::version is greater than \a ver. **/
     member_adapter_builder& after(version ver)
     {
@@ -929,7 +929,7 @@ public:
                          }
                         );
     }
-    
+
     /** Only encode this member if the \c serialization_context::version is less than \a ver. **/
     member_adapter_builder& before(version ver)
     {
@@ -939,7 +939,7 @@ public:
                          }
                         );
     }
-    
+
 private:
     detail::member_adapter_impl<T, TMember>* _adapter;
 };
@@ -962,31 +962,31 @@ public:
         auto adapter = std::make_shared<adapter_impl>();
         register_adapter(adapter);
         _adapter = adapter.get();
-        
+
         std::forward<F>(f)(*this);
     }
-    
+
     explicit adapter_builder(formats_builder* owner) :
             adapter_builder(owner, [] (const adapter_builder<T>&) { })
     { }
-    
+
     adapter_builder<T>& type_default_on_null(bool on = true)
     {
         _adapter->_default_on_null = on;
         return *this;
     }
-    
+
     adapter_builder<T>& type_default_value(std::function<T (const extraction_context& ctx)> create)
     {
         _adapter->_create_default = std::move(create);
         return *this;
     }
-    
+
     adapter_builder<T>& type_default_value(const T& value)
     {
         return type_default_value([value] (const extraction_context&) { return T(value); });
     }
-    
+
     template <typename TMember>
     member_adapter_builder<T, TMember> member(std::string name, TMember T::*selector)
     {
@@ -1049,7 +1049,7 @@ public:
                                std::function<void (T&, TMember&&)>(mutate)
                               );
     }
-    
+
     adapter_builder<T>& pre_extract(pre_extract_func perform)
     {
         if (_adapter->_pre_extract)
@@ -1084,7 +1084,7 @@ public:
         }
         return *this;
     }
-    
+
     adapter_builder<T>& on_extract_extra_keys(extra_keys_func handler)
     {
         adapter_impl* adapter = _adapter;
@@ -1107,7 +1107,7 @@ public:
                 handler(context, from, std::move(extra_keys));
         });
     }
-    
+
 private:
     class adapter_impl :
             public adapter_for<T>
@@ -1116,15 +1116,15 @@ private:
         adapter_impl() :
                 _default_on_null(false)
         { }
-    
+
         virtual T create(const extraction_context& context, const value& from) const override
         {
             if (_pre_extract)
                 _pre_extract(context, from);
-            
+
             if (_default_on_null && from.is_null())
                 return _create_default(context);
-            
+
             T out;
             for (const auto& member : _members)
                 member->mutate(context, from, out);
@@ -1134,7 +1134,7 @@ private:
 
             return out;
         }
-        
+
         virtual value to_json(const serialization_context& context, const T& from) const override
         {
             value out = object();
@@ -1142,14 +1142,14 @@ private:
                 member->to_json(context, from, out);
             return out;
         }
-        
+
         std::deque<std::unique_ptr<detail::member_adapter<T>>> _members;
         pre_extract_func                                       _pre_extract;
         post_extract_func                                      _post_extract;
         std::function<T (const extraction_context&)>           _create_default;
         bool                                                   _default_on_null;
     };
-    
+
 private:
     adapter_impl* _adapter;
 };
@@ -1171,39 +1171,39 @@ public:
         auto adapter = std::make_shared<polymorphic_adapter<TPointer>>();
         register_adapter(adapter);
         _adapter = adapter.get();
-        
+
         std::forward<F>(f)(*this);
     }
-    
+
     explicit polymorphic_adapter_builder(formats_builder* owner, std::string discrimination_key = "") :
             polymorphic_adapter_builder(owner,
                                         std::move(discrimination_key),
                                         [] (const polymorphic_adapter_builder<TPointer>&) { }
                                        )
     { }
-    
+
     polymorphic_adapter_builder& check_null_input(bool on = true)
     {
         _adapter->check_null_input(on);
         return *this;
     }
-    
+
     polymorphic_adapter_builder& check_null_output(bool on = true)
     {
         _adapter->check_null_output(on);
         return *this;
     }
-    
+
     template <typename TSub>
     polymorphic_adapter_builder& subtype(value discrimination_value,
                                          keyed_subtype_action action = keyed_subtype_action::none)
     {
         if (_discrimination_key.empty())
             throw std::logic_error("Cannot use single-argument subtype if no discrimination_key has been set");
-        
+
         return subtype<TSub>(_discrimination_key, std::move(discrimination_value), action);
     }
-        
+
     template <typename TSub>
     polymorphic_adapter_builder& subtype(std::string discrimination_key,
                                          value discrimination_value,
@@ -1215,7 +1215,7 @@ public:
         reference_type(std::type_index(typeid(TSub)), std::type_index(typeid(TPointer)));
         return *this;
     }
-        
+
     template <typename TSub>
     polymorphic_adapter_builder& subtype(std::function<bool (const extraction_context&, const value&)> discriminator)
     {
@@ -1223,7 +1223,7 @@ public:
         reference_type(std::type_index(typeid(TSub)), std::type_index(typeid(TPointer)));
         return *this;
     }
-        
+
     template <typename TSub>
     polymorphic_adapter_builder& subtype(std::function<bool (const value&)> discriminator)
     {
@@ -1233,7 +1233,7 @@ public:
                              }
                             );
     }
-    
+
 private:
     polymorphic_adapter<TPointer>* _adapter;
     std::string                    _discrimination_key;
@@ -1243,19 +1243,19 @@ class JSONV_PUBLIC formats_builder
 {
 public:
     formats_builder();
-    
+
     template <typename T>
     adapter_builder<T> type()
     {
         return adapter_builder<T>(this);
     }
-    
+
     template <typename T, typename F>
     adapter_builder<T> type(F&& f)
     {
         return adapter_builder<T>(this, std::forward<F>(f));
     }
-    
+
     template <typename TEnum>
     formats_builder& enum_type(std::string                                    enum_name,
                                std::initializer_list<std::pair<TEnum, value>> mapping
@@ -1263,7 +1263,7 @@ public:
     {
         return register_adapter(std::make_shared<enum_adapter<TEnum>>(std::move(enum_name), mapping));
     }
-    
+
     template <typename TEnum>
     formats_builder& enum_type_icase(std::string                                    enum_name,
                                      std::initializer_list<std::pair<TEnum, value>> mapping
@@ -1271,34 +1271,34 @@ public:
     {
         return register_adapter(std::make_shared<enum_adapter_icase<TEnum>>(std::move(enum_name), mapping));
     }
-    
+
     template <typename TPointer>
     polymorphic_adapter_builder<TPointer>
     polymorphic_type(std::string discrimination_key = "")
     {
         return polymorphic_adapter_builder<TPointer>(this, std::move(discrimination_key));
     }
-    
+
     template <typename TPointer, typename F>
     polymorphic_adapter_builder<TPointer>
     polymorphic_type(std::string discrimination_key, F&& f)
     {
         return polymorphic_adapter_builder<TPointer>(this, std::move(discrimination_key), std::forward<F>(f));
     }
-    
+
     template <typename F>
     formats_builder& extend(F&& func)
     {
         std::forward<F>(func)(*this);
         return *this;
     }
-    
+
     formats_builder& register_adapter(const adapter* p)
     {
         _formats.register_adapter(p, _duplicate_type_action);
         return *this;
     }
-    
+
     formats_builder& register_adapter(std::shared_ptr<const adapter> p)
     {
         _formats.register_adapter(std::move(p), _duplicate_type_action);
@@ -1331,14 +1331,14 @@ public:
         _formats.register_adapter(std::move(p), _duplicate_type_action);
         return *this;
     }
-    
+
     #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
     template <typename T>
     formats_builder& register_containers()
     {
         return *this;
     }
-    
+
     template <typename T, template <class...> class TTContainer, template <class...> class... TTRest>
     formats_builder& register_containers()
     {
@@ -1346,15 +1346,15 @@ public:
         return register_containers<T, TTRest...>();
     }
     #endif
-    
+
     operator formats() const
     {
         return _formats;
     }
-    
+
     formats_builder& reference_type(std::type_index type);
     formats_builder& reference_type(std::type_index type, std::type_index from);
-    
+
     /// \{
     /// Check that, when combined with the \c formats \a other, all types referenced by this \c formats_builder will
     /// get decoded properly.
@@ -1381,7 +1381,7 @@ public:
      *  there is already a serializer or extracter for that type.
     **/
     formats_builder& on_duplicate_type(duplicate_type_action action) noexcept;
-    
+
 private:
     void check_references_impl(const formats& searching, const std::string& name);
 
@@ -1558,7 +1558,7 @@ adapter_builder<T>& adapter_builder_dsl<T>::on_extract_extra_keys(typename adapt
 }
 
 /** Throw an \a extraction_error indicating that \a from had extra keys.
- *  
+ *
  *  \throws extraction_error always.
 **/
 JSONV_PUBLIC JSONV_NO_RETURN

--- a/src/jsonv-tests/serialization_builder_tests.cpp
+++ b/src/jsonv-tests/serialization_builder_tests.cpp
@@ -1,6 +1,6 @@
 /** \file
  *
- *  Copyright (c) 2015 by Travis Gockel. All rights reserved.
+ *  Copyright (c) 2015-2019 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
  *  as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
@@ -329,26 +329,26 @@ namespace
 
 struct foo
 {
-  int         a;
-  int         b;
-  std::string c;
-  
-  static foo create_default()
-  {
-      foo out;
-      out.a = 0;
-      out.b = 1;
-      out.c = "default";
-      return out;
-  }
+    int         a;
+    int         b;
+    std::string c;
+
+    static foo create_default()
+    {
+        foo out;
+        out.a = 0;
+        out.b = 1;
+        out.c = "default";
+        return out;
+    }
 };
 
 struct bar
 {
-  foo         x;
-  foo         y;
-  std::string z;
-  std::string w;
+    foo         x;
+    foo         y;
+    std::string z;
+    std::string w;
 };
 
 TEST(serialization_builder_extra_unchecked_key)
@@ -370,14 +370,14 @@ TEST(serialization_builder_extra_unchecked_key)
                    .until(jsonv::version(5, 0))
     ;
     jsonv::formats format = jsonv::formats::compose({ jsonv::formats::defaults(), local_formats });
-    
-    jsonv::value val = object({ { "x", object({ { "aaaaa", 50 }, { "b", 20 }, { "c", "Blah"  } }) },
-                                { "y", object({ { "a",     10 },              { "c", "No B?" } }) },
+
+    jsonv::value val = object({ { "x", object({ { "a", 50 }, { "b", 20 }, { "c", "Blah"  }, {  "extra", "key" } }) },
+                                { "y", object({ { "a", 10 },              { "c", "No B?" } }) },
                                 { "z", "Only serialized in 2.0+" },
                                 { "w", "Only serialized before 5.0" }
                               }
                              );
-    bar x = jsonv::extract<bar>(val, format);  
+    bar x = jsonv::extract<bar>(val, format);
 }
 
 TEST(serialization_builder_extra_unchecked_key_throws)
@@ -400,9 +400,9 @@ TEST(serialization_builder_extra_unchecked_key_throws)
                    .until(jsonv::version(5, 0))
     ;
     jsonv::formats format = jsonv::formats::compose({ jsonv::formats::defaults(), local_formats });
-    
-    jsonv::value val = object({ { "x", object({ { "aaaaa", 50 }, { "b", 20 }, { "c", "Blah"  } }) },
-                                { "y", object({ { "a",     10 },              { "c", "No B?" } }) },
+
+    jsonv::value val = object({ { "x", object({ { "a", 50 }, { "b", 20 }, { "c", "Blah"  }, { "extra", "key" } }) },
+                                { "y", object({ { "a", 10 },              { "c", "No B?" } }) },
                                 { "z", "Only serialized in 2.0+" },
                                 { "w", "Only serialized before 5.0" }
                               }
@@ -430,7 +430,7 @@ TEST(serialization_builder_type_based_default_value)
                 .type_default_value(foo::create_default())
         ;
     jsonv::formats format = jsonv::formats::compose({ jsonv::formats::defaults(), local_formats });
-    
+
     auto f = jsonv::extract<foo>(value(), format);
     auto e = foo::create_default();
     ensure_eq(e.a, f.a);
@@ -500,7 +500,7 @@ enum class ring
 TEST(serialization_builder_enum_strings)
 {
     using namespace x;
-    
+
     jsonv::formats formats =
         jsonv::formats_builder()
             .enum_type<ring>("ring",
@@ -518,21 +518,21 @@ TEST(serialization_builder_enum_strings)
             .register_container<std::vector<ring>>()
             #endif
             .check_references();
-    
+
     ensure(ring::fire  == jsonv::extract<ring>("fire",  formats));
     ensure(ring::wind  == jsonv::extract<ring>("wind",  formats));
     ensure(ring::water == jsonv::extract<ring>("water", formats));
     ensure(ring::earth == jsonv::extract<ring>("earth", formats));
     ensure(ring::heart == jsonv::extract<ring>("heart", formats));
-    
+
     jsonv::value jsons = jsonv::array({ "fire", "wind", "water", "earth", "heart" });
     std::vector<ring> exp = { ring::fire, ring::wind, ring::water, ring::earth, ring::heart };
     std::vector<ring> val = jsonv::extract<std::vector<ring>>(jsons, formats);
     ensure(val == exp);
-    
+
     value enc = jsonv::to_json(exp, formats);
     ensure(enc == jsons);
-    
+
     ensure_throws(jsonv::extraction_error, jsonv::extract<ring>("FIRE",    formats));
     ensure_throws(jsonv::extraction_error, jsonv::extract<ring>("useless", formats));
 }
@@ -540,7 +540,7 @@ TEST(serialization_builder_enum_strings)
 TEST(serialization_builder_enum_strings_icase)
 {
     using namespace x;
-    
+
     jsonv::formats formats =
         jsonv::formats_builder()
             .enum_type_icase<ring>("ring",
@@ -558,28 +558,28 @@ TEST(serialization_builder_enum_strings_icase)
             .register_container<std::vector<ring>>()
             #endif
             .check_references(jsonv::formats::defaults());
-    
+
     ensure(ring::fire  == jsonv::extract<ring>("fiRe",  formats));
     ensure(ring::wind  == jsonv::extract<ring>("wIND",  formats));
     ensure(ring::water == jsonv::extract<ring>("Water", formats));
     ensure(ring::earth == jsonv::extract<ring>("EARTH", formats));
     ensure(ring::heart == jsonv::extract<ring>("HEART", formats));
-    
+
     jsonv::value jsons = jsonv::array({ "fire", "wind", "water", "earth", "heart" });
     std::vector<ring> exp = { ring::fire, ring::wind, ring::water, ring::earth, ring::heart };
     std::vector<ring> val = jsonv::extract<std::vector<ring>>(jsons, formats);
     ensure(val == exp);
-    
+
     value enc = jsonv::to_json(exp, formats);
     ensure(enc == jsons);
-    
+
     ensure_throws(jsonv::extraction_error, jsonv::extract<ring>("useless", formats));
 }
 
 TEST(serialization_builder_enum_strings_icase_multimapping)
 {
     using namespace x;
-    
+
     jsonv::formats formats =
         jsonv::formats_builder()
             .enum_type_icase<ring>("ring",
@@ -600,7 +600,7 @@ TEST(serialization_builder_enum_strings_icase_multimapping)
              .register_container<std::vector<ring>>()
              #endif
             .check_references(jsonv::formats::defaults());
-    
+
     ensure(ring::fire  == jsonv::extract<ring>("fiRe",  formats));
     ensure(ring::fire  == jsonv::extract<ring>(666,     formats));
     ensure(ring::wind  == jsonv::extract<ring>("wIND",  formats));
@@ -609,15 +609,15 @@ TEST(serialization_builder_enum_strings_icase_multimapping)
     ensure(ring::earth == jsonv::extract<ring>(true, formats));
     ensure(ring::heart == jsonv::extract<ring>("HEART", formats));
     ensure(ring::heart == jsonv::extract<ring>("useless", formats));
-    
+
     jsonv::value jsons = jsonv::array({ "fire", "wind", "water", "earth", "heart" });
     std::vector<ring> exp = { ring::fire, ring::wind, ring::water, ring::earth, ring::heart };
     std::vector<ring> val = jsonv::extract<std::vector<ring>>(jsons, formats);
     ensure(val == exp);
-    
+
     value enc = jsonv::to_json(exp, formats);
     ensure(enc == jsons);
-    
+
     ensure_throws(jsonv::extraction_error, jsonv::extract<ring>(false, formats));
     ensure_throws(jsonv::extraction_error, jsonv::extract<ring>(5,     formats));
 }
@@ -634,12 +634,12 @@ struct a_derived :
         base
 {
     virtual std::string get() const override { return "a"; }
-    
+
     static void json_adapt(adapter_builder<a_derived>& builder)
     {
         builder.member("type", &a_derived::x);
     }
-    
+
     std::string x = "a";
 };
 
@@ -647,7 +647,7 @@ struct b_derived :
         base
 {
     virtual std::string get() const override { return "b"; }
-    
+
     static void json_adapt(adapter_builder<b_derived>& builder)
     {
         builder.member("type", &b_derived::x);
@@ -713,15 +713,15 @@ TEST(serialization_builder_polymorphic_direct)
                                      .subtype<a_derived>("a")
                                      .subtype<a_derived>("a");
                          };
-    
+
     auto fmts = make_fmts(b_derived::json_adapt, c_derived::json_adapt);
     value input = array({ object({{ "type", "a" }}), object({{ "type", "b" }}), object({{ "type", "c" }}) });
     auto output = extract<std::vector<std::unique_ptr<base>>>(input, fmts);
-    
+
     ensure(output.at(0)->get() == "a");
     ensure(output.at(1)->get() == "b");
     ensure(output.at(2)->get() == "c");
-    
+
     value encoded = to_json(output, fmts);
     ensure_eq(input, encoded);
 


### PR DESCRIPTION
Previously, missing keys would simply be left uninitialized, which was
slightly problematic. In usage, this would invoke undefined behavior and
also violated the serialization builder documentation:

> If a `default_value` is not specified, the key is required.

This changeset also changes the error message thrown from
`extraction_context::extract` and `extraction_context::extract_sub` when
the type does not derive from `std::exception` to attempt to extract the
exception type from the CXXABI (if available in C++17). This uses a
different detection mechanism than `demangle.cpp`, which just looks for
the non-presence of `_MSC_VER`. This should be change in 2.0.

Fixes issue #124.