### PR TITLE
Use `__has_include` (if present) to check for `<cxxabi.h>`.

### DIFF
--- a/include/jsonv/demangle.hpp
+++ b/include/jsonv/demangle.hpp
@@ -1,5 +1,5 @@
 /** \file jsonv/demangle.hpp
- *  
+ *
  *  Copyright (c) 2015 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -26,14 +26,14 @@ namespace jsonv
 
 /** Convert the input \a source from a mangled type into a human-friendly version. This is used by \c formats (and the
  *  associated serialization functions) to give more user-friendly names in type errors.
- *  
+ *
  *  \see demangle_function
  *  \see set_demangle_function
 **/
 JSONV_PUBLIC std::string demangle(string_view source);
 
 /** Type of function used in setting a custom demangler.
- *  
+ *
  *  \see demangle
  *  \see set_demangle_function
 **/
@@ -41,16 +41,25 @@ using demangle_function = std::function<std::string (string_view source)>;
 
 /** Sets the global demangle function. This controls the behavior of \c demangle -- the provided \a func will be called
  *  by \c demangle.
- *  
- *  \see demangle 
+ *
+ *  \see demangle
 **/
 JSONV_PUBLIC void set_demangle_function(demangle_function func);
 
 /** Resets the demangle function to the default.
- *  
+ *
  *  \see set_demangle_function
 **/
 JSONV_PUBLIC void reset_demangle_function();
+
+/** Get the demangled type name of the current exception. This is meant to be called from `catch (...)` blocks to
+ *  attempt to get more information about the exception type when it doesn't derive from a known entity.
+ *
+ *  \returns The demangled type name of the current exception or "unknown" if this cannot be discovered. Failure to
+ *   discover is not an error -- this can happen if the exception is foreign to C++ (it does not have a
+ *   \c std::type_info implementation) or if discovery is not known for this platform.
+**/
+JSONV_PUBLIC std::string current_exception_type_name();
 
 /** \} **/
 

--- a/src/jsonv/serialization.cpp
+++ b/src/jsonv/serialization.cpp
@@ -21,17 +21,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#if __cplusplus >= 201703L
-#   if __has_include(<cxxabi.h>)
-#       define JSONV_HAS_CXXABI 1
-#       include <cxxabi.h>
-#   else
-#       define JSONV_HAS_CXXABI 0
-#   endif
-#else
-#   define JSONV_HAS_CXXABI 0
-#endif
-
 namespace jsonv
 {
 
@@ -634,16 +623,6 @@ extraction_context::extraction_context() :
 { }
 
 extraction_context::~extraction_context() noexcept = default;
-
-static std::string current_exception_type_name()
-{
-    #if JSONV_HAS_CXXABI
-    if (auto type_ptr = __cxxabiv1::__cxa_current_exception_type())
-        return demangle(type_ptr->name());
-    #endif
-
-    return "unknown";
-}
 
 void extraction_context::extract(const std::type_info& type, const value& from, void* into) const
 {


### PR DESCRIPTION
Fixes issue #129.