### PR TITLE
Removes all usage of Boost from the project.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ env:
   - DISTRO=ubuntu-16.04  CONF=Release
   - DISTRO=ubuntu-18.04  CONF=Debug
   - DISTRO=ubuntu-18.04  CONF=Release
-  - DISTRO=ubuntu-18.10  CONF=Debug
-  - DISTRO=ubuntu-18.10  CONF=Release
-  - DISTRO=ubuntu-19.04  CONF=Debug
-  - DISTRO=ubuntu-19.04  CONF=Release
+  - DISTRO=ubuntu-19.10  CONF=Debug
+  - DISTRO=ubuntu-19.10  CONF=Release
   - DISTRO=debian-9.9    CONF=Debug
   - DISTRO=debian-9.9    CONF=Release
+  - DISTRO=debian-10.1   CONF=Debug
+  - DISTRO=debian-10.1   CONF=Release
+  - DISTRO=debian-10.2   CONF=Debug
+  - DISTRO=debian-10.2   CONF=Release
   - DISTRO=opensuse-15.1 CONF=Debug
   - DISTRO=opensuse-15.1 CONF=Release
   - DISTRO=fedora-27     CONF=Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,6 @@ option(JSONV_BUILD_TESTS
        OFF
       )
 
-set(REQUIRED_BOOST_LIBRARIES)
-
-if (JSONV_BUILD_TESTS)
-    list(APPEND REQUIRED_BOOST_LIBRARIES "filesystem" "system")
-endif()
-
 #############################
 # String View Configuration #
 #############################
@@ -147,13 +141,6 @@ include_directories("${PROJECT_SOURCE_DIR}/include"
                     "${PROJECT_SOURCE_DIR}/src"
                    )
 
-set(Boost_USE_MULTITHREADED ON)
-find_package(Boost
-             COMPONENTS "${REQUIRED_BOOST_LIBRARIES}"
-             REQUIRED
-            )
-include_directories(${Boost_INCLUDE_DIRS})
-
 add_definitions("-DJSONV_TEST_DATA_DIR=\"${CMAKE_SOURCE_DIR}/src/jsonv-tests/data\"")
 
 configure_file(libjsonv.pc.in libjsonv.pc)
@@ -169,16 +156,12 @@ set_target_properties(jsonv
                         SOVERSION ${JSONV_SO_VERSION}
                         VERSION   ${JSONV_SO_VERSION}
                      )
-if (Boost_LIBRARIES)
-    target_link_libraries(jsonv ${Boost_LIBRARIES})
-endif()
 
 if (JSONV_BUILD_TESTS)
     file(GLOB_RECURSE jsonv_tests_cpps RELATIVE_PATH "." "src/jsonv-tests/*.cpp")
     add_executable(jsonv-tests ${jsonv_tests_cpps})
     target_link_libraries(jsonv-tests
             "jsonv"
-            ${Boost_LIBRARIES}
         )
 
     add_custom_target(check
@@ -247,7 +230,6 @@ if (BENCHMARK)
     add_executable(json-benchmark ${BENCHMARK_CPPS})
     target_link_libraries(json-benchmark
         ${BENCHMARK_LIBS}
-        ${Boost_LIBRARIES}
     )
 endif(BENCHMARK)
 

--- a/config/docker/debian-10.1/Dockerfile
+++ b/config/docker/debian-10.1/Dockerfile
@@ -1,12 +1,12 @@
-FROM archlinux/base
+FROM debian:10.1
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN pacman -Sy --noconfirm  \
+RUN apt-get update          \
+ && apt-get install --yes   \
     cmake                   \
-    gcc                     \
-    git                     \
     grep                    \
-    make                    \
-    ninja
+    g++                     \
+    lcov                    \
+    ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/debian-10.2/Dockerfile
+++ b/config/docker/debian-10.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM debian:10.2
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
 RUN apt-get update          \
@@ -7,7 +7,6 @@ RUN apt-get update          \
     grep                    \
     g++                     \
     lcov                    \
-    libboost-all-dev        \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/fedora-27/Dockerfile
+++ b/config/docker/fedora-27/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
 RUN dnf refresh             \
  && dnf install -y          \
-    boost-devel             \
     cmake                   \
     grep                    \
     gcc-c++                 \

--- a/config/docker/fedora-30/Dockerfile
+++ b/config/docker/fedora-30/Dockerfile
@@ -2,7 +2,6 @@ FROM fedora:30
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
 RUN dnf install -y --refresh    \
-    boost-devel                 \
     cmake                       \
     grep                        \
     gcc-c++                     \

--- a/config/docker/ubuntu-16.04/Dockerfile
+++ b/config/docker/ubuntu-16.04/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update          \
     grep                    \
     g++                     \
     lcov                    \
-    libboost-all-dev        \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/ubuntu-18.04/Dockerfile
+++ b/config/docker/ubuntu-18.04/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update          \
     grep                    \
     g++                     \
     lcov                    \
-    libboost-all-dev        \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/ubuntu-19.10/Dockerfile
+++ b/config/docker/ubuntu-19.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
 RUN apt-get update          \
@@ -7,7 +7,6 @@ RUN apt-get update          \
     grep                    \
     g++                     \
     lcov                    \
-    libboost-all-dev        \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/src/json-benchmark/main.cpp
+++ b/src/json-benchmark/main.cpp
@@ -1,5 +1,5 @@
 /** \file
- *  
+ *
  *  Copyright (c) 2015 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -20,56 +20,66 @@
 #include <random>
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
-
 using namespace jsonv;
+
+static int extract_int(string_view src)
+{
+    auto  src_end  = src.data() + src.size();
+    char* scan_end = nullptr;
+    auto  val      = std::strtol(src.data(), &scan_end, 10);
+
+    if (scan_end == src_end)
+        return int(val);
+    else
+        throw std::invalid_argument(std::string("Could not extract integer from \"") + std::string(src) + "\"");
+}
 
 struct generated_json_settings
 {
     std::uniform_int_distribution<int> kind_distribution{0, 6};
-    
+
     template <typename TRng>
     jsonv::kind kind(TRng& rng, std::size_t current_depth)
     {
         if (current_depth < 2)
             return jsonv::kind::object;
-        
+
         auto k = static_cast<jsonv::kind>(kind_distribution(rng));
         if (current_depth > 5 && (k == jsonv::kind::array || k == jsonv::kind::object))
             return kind(rng, current_depth);
         else
             return k;
     }
-    
+
     std::uniform_int_distribution<std::size_t> array_length_distribution{0, 100};
     template <typename TRng>
     std::size_t array_length(TRng& rng)
     {
         return array_length_distribution(rng);
     }
-    
+
     std::uniform_int_distribution<std::size_t> object_size_distribution{5, 25};
     template <typename TRng>
     std::size_t object_size(TRng& rng)
     {
         return object_size_distribution(rng);
     }
-    
+
     std::uniform_int_distribution<std::int64_t> string_length_distribution{0, 100};
     template <typename TRng>
     std::size_t string_length(TRng& rng)
     {
         return string_length_distribution(rng);
     }
-    
-    
+
+
     std::normal_distribution<> decimal_distribution{1.0, 40.0};
     template <typename TRng>
     double decimal(TRng& rng)
     {
         return decimal_distribution(rng);
     }
-    
+
     std::uniform_int_distribution<std::int64_t> integer_distribution{~0};
     template <typename TRng>
     std::int64_t integer(TRng& rng)
@@ -125,48 +135,48 @@ public:
     using clock      = std::chrono::steady_clock;
     using time_point = clock::time_point;
     using duration   = std::chrono::nanoseconds;
-    
+
     struct ticker
     {
         stopwatch* owner;
         time_point start_time;
-        
+
         ticker(stopwatch* o) :
                 owner(o),
                 start_time(clock::now())
         { }
-        
+
         ticker(ticker&& src) :
                 owner(src.owner),
                 start_time(src.start_time)
         {
             src.owner = nullptr;
         }
-        
+
         ~ticker()
         {
             if (owner)
                 owner->add_time(clock::now() - start_time);
         }
     };
-    
+
 public:
     stopwatch() :
             tick_count(0),
             total_time(duration(0))
     { }
-    
+
     ticker start()
     {
         return ticker(this);
     }
-    
+
     void add_time(duration dur)
     {
         ++tick_count;
         total_time += dur;
     }
-    
+
 public:
     std::size_t tick_count;
     duration    total_time;
@@ -181,7 +191,7 @@ static std::string get_encoded_json()
         buff << in.rdbuf();
         return buff.str();
     }
-    
+
     std::ostringstream encoded_stream;
     ostream_pretty_encoder out(encoded_stream);
     std::mt19937_64 rng{std::random_device()()};
@@ -189,7 +199,7 @@ static std::string get_encoded_json()
     value val = generate_json(rng, settings);
     out.encode(val);
     std::string encoded = encoded_stream.str();
-    
+
     // save the string to a file in case we want to re-use it
     std::ofstream file("temp.json", std::ofstream::out | std::ofstream::trunc);
     file << encoded;
@@ -199,22 +209,22 @@ static std::string get_encoded_json()
 int main(int argc, char** argv)
 {
     using namespace json_benchmark;
-    
+
     std::string filter;
     if (argc >= 2)
         filter = argv[1];
-    
+
     int loop_count = 10;
     if (argc >= 3)
-        loop_count = boost::lexical_cast<int>(argv[2]);
-    
+        loop_count = extract_int(argv[2]);
+
     std::string encoded = get_encoded_json();
-    
+
     for (const benchmark_suite* suite : benchmark_suite::all())
     {
         if (!filter.empty() && filter != suite->name())
             continue;
-        
+
         std::cout << std::endl;
         stopwatch watch;
         for (int idx = 1; idx <= loop_count; ++idx)
@@ -225,7 +235,7 @@ int main(int argc, char** argv)
             suite->parse_test(encoded);
         }
         std::cout << std::endl;
-        
+
         auto average = std::chrono::duration_cast<std::chrono::duration<double>>(watch.total_time) / watch.tick_count;
         std::cout << suite->name() << '\t' << average.count();// << std::endl;
     }

--- a/src/jsonv-tests/benchmark_tests.cpp
+++ b/src/jsonv-tests/benchmark_tests.cpp
@@ -1,6 +1,6 @@
 /** \file
- *  
- *  Copyright (c) 2016 by Travis Gockel. All rights reserved.
+ *
+ *  Copyright (c) 2016-2019 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
  *  as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
@@ -73,8 +73,15 @@ public:
     {
         recursive_directory_for_each(rootpath, ".json", [&, this] (const std::string& path)
         {
-            _tests.emplace_back(new benchmark_test<std::ifstream>([] (const std::string& p) { return p; }, "ifstream", path));
-            _tests.emplace_back(new benchmark_test<std::string>(load_from_file, "string", path));
+            if (path.find("fail") == std::string::npos)
+            {
+                _tests.emplace_back(new benchmark_test<std::ifstream>([] (const std::string& p) { return p; },
+                                                                      "ifstream",
+                                                                      path
+                                                                     )
+                                   );
+                _tests.emplace_back(new benchmark_test<std::string>(load_from_file, "string", path));
+            }
         });
     }
 

--- a/src/jsonv/path.cpp
+++ b/src/jsonv/path.cpp
@@ -1,5 +1,5 @@
 /** \file
- *  
+ *
  *  Copyright (c) 2014 by Travis Gockel. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -20,8 +20,6 @@
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
-
-#include <boost/lexical_cast.hpp>
 
 namespace jsonv
 {
@@ -120,7 +118,7 @@ path_element& path_element::operator=(const path_element& src)
             _data.key = src._data.key;
         }
     }
-    
+
     return *this;
 }
 
@@ -162,7 +160,7 @@ path_element& path_element::operator=(path_element&& src) noexcept
             _data.key = std::move(src._data.key);
         }
     }
-    
+
     return *this;
 }
 
@@ -269,6 +267,18 @@ path& path::operator=(path&& src) noexcept
 }
 path::~path() noexcept = default;
 
+static std::size_t extract_size_t(string_view src)
+{
+    auto  src_end  = src.data() + src.size();
+    char* scan_end = nullptr;
+    auto  val      = std::strtoull(src.data(), &scan_end, 10);
+
+    if (scan_end == src_end)
+        return val;
+    else
+        throw std::invalid_argument(std::string("Could not extract integer from \"") + std::string(src) + "\"");
+}
+
 path path::create(string_view specification)
 {
     path out;
@@ -285,17 +295,17 @@ path path::create(string_view specification)
             if (match.at(1) == '\"')
                 out += detail::get_string_decoder(parse_options::encoding::utf8)(match.substr(2, match.size() - 4));
             else
-                out += boost::lexical_cast<std::size_t>(match.data() + 1, match.size() - 2);
+                out += extract_size_t(string_view(match.data() + 1, match.size() - 2));
             break;
         default:
             throw std::invalid_argument(std::string("Invalid specification \"") + std::string(specification) + "\". "
                                         +"Syntax error at \"" + std::string(remaining) + "\""
                                        );
         }
-            
+
         remaining.remove_prefix(match.size());
     }
-    
+
     return out;
 }
 


### PR DESCRIPTION
Boost has been a build-time dependency for a while, but packaging in C++
is such a pain that it seems easier to reinvent the wheel instead of
continuing to deal with the constantly-changing packaging of Boost
across 5 distros.

Fixes issue #137.