### PR TITLE
Build Docker images with noninteractive frontend.

### DIFF
--- a/config/docker/debian-10.1/Dockerfile
+++ b/config/docker/debian-10.1/Dockerfile
@@ -1,12 +1,13 @@
 FROM debian:10.1
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN apt-get update          \
- && apt-get install --yes   \
-    cmake                   \
-    grep                    \
-    g++                     \
-    lcov                    \
+RUN apt-get update                  \
+ && DEBIAN_FRONTEND=noninteractive  \
+    apt-get install --yes           \
+    cmake                           \
+    grep                            \
+    g++                             \
+    lcov                            \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/debian-10.2/Dockerfile
+++ b/config/docker/debian-10.2/Dockerfile
@@ -1,12 +1,13 @@
 FROM debian:10.2
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN apt-get update          \
- && apt-get install --yes   \
-    cmake                   \
-    grep                    \
-    g++                     \
-    lcov                    \
+RUN apt-get update                  \
+ && DEBIAN_FRONTEND=noninteractive  \
+    apt-get install --yes           \
+    cmake                           \
+    grep                            \
+    g++                             \
+    lcov                            \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/ubuntu-18.04/Dockerfile
+++ b/config/docker/ubuntu-18.04/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:18.04
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN apt-get update          \
- && apt-get install --yes   \
-    cmake                   \
-    grep                    \
-    g++                     \
-    lcov                    \
+RUN apt-get update                  \
+ && DEBIAN_FRONTEND=noninteractive  \
+    apt-get install --yes           \
+    cmake                           \
+    grep                            \
+    g++                             \
+    lcov                            \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/ubuntu-19.10/Dockerfile
+++ b/config/docker/ubuntu-19.10/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:19.10
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN apt-get update          \
- && apt-get install --yes   \
-    cmake                   \
-    grep                    \
-    g++                     \
-    lcov                    \
+RUN apt-get update                  \
+ && DEBIAN_FRONTEND=noninteractive  \
+    apt-get install --yes           \
+    cmake                           \
+    grep                            \
+    g++                             \
+    lcov                            \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]

--- a/config/docker/ubuntu-20.04/Dockerfile
+++ b/config/docker/ubuntu-20.04/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:20.04
 LABEL maintainer="Travis Gockel <travis@gockelhut.com>"
 
-RUN apt-get update          \
- && apt-get install --yes   \
-    cmake                   \
-    grep                    \
-    g++                     \
-    lcov                    \
+RUN apt-get update                  \
+ && DEBIAN_FRONTEND=noninteractive  \
+    apt-get install --yes           \
+    cmake                           \
+    grep                            \
+    g++                             \
+    lcov                            \
     ninja-build
 
 CMD ["/root/jsonv/config/run-tests"]


### PR DESCRIPTION
Calling `apt-get install` in all Debian-based Docker image builds now
sets `DEBIAN_FRONTEND=noninteractive`.

- Fixes #159