### PR TITLE
Fix warnings under C++ 17

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,4 +6,5 @@ Travis Gockel      <travis@gockelhut.com>
 
 Contributions by:
 Remy Chibois       <remy.chibois@expandium.com>            - Debian packaging, bugfixes
+Peter Ellis        <peter.ellis@platypustech.co.uk>        - C++ 17 warning fixes
 sth                <https://github.com/sth>                - bugfixes

--- a/include/jsonv/encode.hpp
+++ b/include/jsonv/encode.hpp
@@ -16,6 +16,7 @@
 #include <jsonv/forward.hpp>
 #include <jsonv/string_view.hpp>
 
+#include <cstdint>
 #include <iosfwd>
 
 namespace jsonv

--- a/include/jsonv/value.hpp
+++ b/include/jsonv/value.hpp
@@ -136,10 +136,14 @@ public:
     
     /** The base type for iterating over array values. **/
     template <typename T, typename TArrayView>
-    struct basic_array_iterator :
-            public std::iterator<std::random_access_iterator_tag, T>
+    struct basic_array_iterator
     {
     public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
         basic_array_iterator() :
                 _owner(0),
                 _index(0)
@@ -289,10 +293,15 @@ public:
      *  \c std::map<std::string, jsonv::value>.
     **/
     template <typename T, typename TIterator>
-    struct basic_object_iterator :
-            public std::iterator<std::bidirectional_iterator_tag, T>
+    struct basic_object_iterator
     {
     public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+
         basic_object_iterator() :
                 _impl()
         { }

--- a/src/jsonv/encode.cpp
+++ b/src/jsonv/encode.cpp
@@ -15,6 +15,7 @@
 #include "detail.hpp"
 
 #include <cmath>
+#include <ostream>
 
 namespace jsonv
 {
@@ -227,7 +228,7 @@ void ostream_pretty_encoder::write_decimal(double value)
     ostream_encoder::write_decimal(value);
 }
 
-void ostream_pretty_encoder::write_integer(int64_t value)
+void ostream_pretty_encoder::write_integer(std::int64_t value)
 {
     write_prefix();
     ostream_encoder::write_integer(value);

--- a/src/jsonv/object.cpp
+++ b/src/jsonv/object.cpp
@@ -247,7 +247,7 @@ void value::insert(std::initializer_list<std::pair<std::wstring, value>> items)
 {
     check_type(jsonv::kind::object, kind());
     for (auto& pair : items)
-         insert(std::move(pair));
+         insert(pair);
 }
 
 value::object_insert_return_type value::insert(object_node_handle&& handle)


### PR DESCRIPTION
Fixes deprecation warnings when building using C++ 17.

Also fixes some includes and types that were not picked up by clang-18