### PR TITLE
Drop old compiler compatibility gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           }
           EOF
 
-          c++ -std=c++17 /tmp/jsonv-smoke.cpp $(pkg-config --cflags --libs libjsonv) -o /tmp/jsonv-smoke
+          c++ -std=c++23 /tmp/jsonv-smoke.cpp $(pkg-config --cflags --libs libjsonv) -o /tmp/jsonv-smoke
           /tmp/jsonv-smoke
 
       - name: Upload package artifacts
@@ -265,10 +265,10 @@ jobs:
 
           New-Item -ItemType Directory -Path smoke | Out-Null
           @'
-          cmake_minimum_required(VERSION 3.12)
+          cmake_minimum_required(VERSION 3.20)
           project(jsonv-smoke CXX)
           add_executable(jsonv-smoke main.cpp)
-          target_compile_features(jsonv-smoke PRIVATE cxx_std_17)
+          target_compile_features(jsonv-smoke PRIVATE cxx_std_23)
           target_include_directories(jsonv-smoke PRIVATE "${JSONV_INCLUDE_DIR}")
           target_link_libraries(jsonv-smoke PRIVATE "${JSONV_LIBRARY}")
           '@ | Set-Content -Path smoke\CMakeLists.txt -Encoding ascii
@@ -362,7 +362,7 @@ jobs:
           }
           EOF
 
-          c++ -std=c++17 /tmp/jsonv-smoke.cpp \
+          c++ -std=c++23 /tmp/jsonv-smoke.cpp \
             -I/usr/local/include \
             -L/usr/local/lib \
             -Wl,-rpath,/usr/local/lib \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.20...3.29)
 project(json-voorhees)
 
 set(PACKAGE_NAME "jsonv"
@@ -38,10 +38,9 @@ set(JSONV_VERSION    "${JSONV_VERSION_MAJOR}.${JSONV_VERSION_MINOR}.${JSONV_VERS
 set(JSONV_SO_VERSION "${JSONV_VERSION_MAJOR}.${JSONV_VERSION_MINOR}")
 message(STATUS "JSONV version: ${JSONV_VERSION} (${JSONV_SO_VERSION})")
 
-set(CXX_STANDARD_DEFAULT "c++17")
-set(CXX_STANDARD ${CXX_STANDARD_DEFAULT}
-    CACHE STRING "The version of the language to use (only applies to GCC and Clang)."
-   )
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(JSONV_BUILD_TESTS
        "Should the unit test library get built?"
@@ -82,7 +81,7 @@ option(BENCHMARK
 if(WIN32)
 else(WIN32)
     # Reasonable compilers...
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=${CXX_STANDARD} -pedantic -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG}   -ggdb -DJSONV_DEBUG=1")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ggdb")
 endif(WIN32)
@@ -108,7 +107,7 @@ file(GLOB_RECURSE jsonv_cpps RELATIVE_PATH "." "src/jsonv/*.cpp")
 add_library(jsonv ${LIBRARY_TYPE} ${jsonv_cpps})
 target_compile_features(jsonv
                         PUBLIC
-                          cxx_std_17
+                          cxx_std_23
                        )
 target_include_directories(jsonv
                            PUBLIC

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ JSON Voorhees
 =============
 
 Yet another [JSON][JSON] library for C++.
-This one touts new C++11 features for developer-friendliness, an extremely slow-speed parser and no dependencies beyond
- a compliant compiler.
+This one targets C++23 for developer-friendliness, an extremely slow-speed parser, and no dependencies beyond a
+compliant compiler and standard library.
 If you love Doxygen, check out the [documentation](http://tgockel.github.io/json-voorhees/).
 
 Features include (but are not necessarily limited to):
@@ -100,11 +100,11 @@ Miscellaneous
 Compiler Support
 ----------------
 
- - Supported
-     - GCC 4.8+
-     - Clang 3.3+
- - Experimental
-     - MSVC 14.0 CTP5+ (Visual C++ 2015)
+JSON Voorhees 2.0 requires a C++23-capable compiler and standard library.
+
+The support contract is the C++23 language mode, not a fixed compiler-version matrix. As examples, modern GCC and Clang
+toolchains should be built with `-std=c++23`; for MSVC, use stable `/std:c++23` support when it is available for your
+toolset. MSVC `/std:c++23preview` is treated as experimental.
 
 Versioning
 ----------

--- a/include/jsonv/all.hpp
+++ b/include/jsonv/all.hpp
@@ -101,7 +101,7 @@ namespace jsonv
 ///
 /// \code
 /// // You can use this hideous syntax if you do not want to bring in the whole jsonv namespace:
-/// using jsonv::operator"" _json;
+/// using jsonv::operator""_json;
 ///
 /// jsonv::value x = R"({
 ///                       "objects": [ "Are fun, too.",

--- a/include/jsonv/config.hpp
+++ b/include/jsonv/config.hpp
@@ -106,26 +106,14 @@
 /// \def JSONV_UNUSED
 /// \brief Note that you know the variable is unused, but make the compiler stop complaining about it.
 #ifndef JSONV_UNUSED
-#   if __has_cpp_attribute(maybe_unused)
-#       define JSONV_UNUSED [[maybe_unused]]
-#   elif defined(__GNUC__)
-#       define JSONV_UNUSED __attribute__((unused))
-#   else
-#       define JSONV_UNUSED
-#   endif
+#   define JSONV_UNUSED [[maybe_unused]]
 #endif
 
 /// \def JSONV_NO_RETURN
 /// \brief Mark that a given function will never return control to the caller, either by exiting or throwing an
 /// exception.
 #ifndef JSONV_NO_RETURN
-#   if __has_cpp_attribute(noreturn)
-#       define JSONV_NO_RETURN [[noreturn]]
-#   elif defined(__GNUC__)
-#       define JSONV_NO_RETURN __attribute__((noreturn))
-#   else
-#       define JSONV_NO_RETURN
-#   endif
+#   define JSONV_NO_RETURN [[noreturn]]
 #endif
 
 /// \def JSONV_ALWAYS_INLINE
@@ -150,26 +138,12 @@
         item(unsigned long long)
 #endif
 
-/// \def JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
-/// Does the compiler properly support template templates? Most compilers do, MSVC does not.
-#ifndef JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
-#   ifdef _MSC_VER
-#       define JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES 0
-#   else
-#       define JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES 1
-#   endif
-#endif
-
 /// \def JSONV_LIKELY
 /// Mark that a section of code is likely to be reached.
 ///
 /// \see JSONV_UNLIKELY
 #ifndef JSONV_LIKELY
-#   if __has_cpp_attribute(likely)
-#       define JSONV_LIKELY [[likely]]
-#   else
-#       define JSONV_LIKELY
-#   endif
+#   define JSONV_LIKELY [[likely]]
 #endif
 
 /// \def JSONV_UNLIKELY
@@ -177,11 +151,7 @@
 ///
 /// \see JSONV_LIKELY
 #ifndef JSONV_UNLIKELY
-#   if __has_cpp_attribute(unlikely)
-#       define JSONV_UNLIKELY [[unlikely]]
-#   else
-#       define JSONV_UNLIKELY
-#   endif
+#   define JSONV_UNLIKELY [[unlikely]]
 #endif
 
 /// \}

--- a/include/jsonv/serialization.hpp
+++ b/include/jsonv/serialization.hpp
@@ -16,6 +16,7 @@
 #include <jsonv/value.hpp>
 #include <jsonv/version.hpp>
 
+#include <exception>
 #include <memory>
 #include <new>
 #include <typeinfo>
@@ -629,10 +630,10 @@ public:
     template <typename T>
     T extract(const value& from) const
     {
-        typename std::aligned_storage<sizeof(T), alignof(T)>::type place[1];
-        T* ptr = reinterpret_cast<T*>(place);
-        extract(typeid(T), from, static_cast<void*>(ptr));
-        auto destroy = detail::on_scope_exit([ptr] { ptr->~T(); });
+        alignas(T) unsigned char place[sizeof(T)];
+        extract(typeid(T), from, static_cast<void*>(place));
+        T* ptr = std::launder(reinterpret_cast<T*>(place));
+        auto destroy = detail::on_scope_exit([ptr] { std::destroy_at(ptr); });
         return std::move(*ptr);
     }
 
@@ -650,10 +651,10 @@ public:
     template <typename T>
     T extract_sub(const value& from, jsonv::path subpath) const
     {
-        typename std::aligned_storage<sizeof(T), alignof(T)>::type place[1];
-        T* ptr = reinterpret_cast<T*>(place);
-        extract_sub(typeid(T), from, std::move(subpath), static_cast<void*>(ptr));
-        auto destroy = detail::on_scope_exit([ptr] { ptr->~T(); });
+        alignas(T) unsigned char place[sizeof(T)];
+        extract_sub(typeid(T), from, std::move(subpath), static_cast<void*>(place));
+        T* ptr = std::launder(reinterpret_cast<T*>(place));
+        auto destroy = detail::on_scope_exit([ptr] { std::destroy_at(ptr); });
         return std::move(*ptr);
     }
 

--- a/include/jsonv/serialization_builder.hpp
+++ b/include/jsonv/serialization_builder.hpp
@@ -235,7 +235,7 @@ namespace jsonv
 ///
 /// \paragraph serialization_builder_dsl_ref_formats_level_register_containers register_containers
 ///
-///  - <tt>register_containers&lt;T, template &lt;T, ...&gt;... TTContainer&gt;</tt>
+///  - <tt>register_containers&lt;T, template &lt;class...&gt; class... TTContainer&gt;</tt>
 ///
 /// Convenience function for calling \c register_container for multiple containers with the same \c value_type.
 /// Unfortunately, it only supports varying the first template parameter of the \c TTContainer types, so if you wish to
@@ -246,9 +246,6 @@ namespace jsonv
 ///   .register_containers<int, std::list, std::deque>()
 ///   .register_containers<double, std::vector, std::set>()
 /// \endcode
-///
-/// \note
-/// Not supported in MSVC 14 (CTP 5).
 ///
 /// \paragraph serialization_builder_dsl_ref_formats_level_register_wrapper register_wrapper
 ///
@@ -602,10 +599,8 @@ public:
     template <typename TContainer>
     formats_builder& register_container();
 
-    #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
     template <typename T, template <class...> class... TTContainers>
     formats_builder& register_containers();
-    #endif
 
     template <typename TWrapper>
     formats_builder& register_wrapper();
@@ -1334,7 +1329,6 @@ public:
         return *this;
     }
 
-    #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
     template <typename T>
     formats_builder& register_containers()
     {
@@ -1347,7 +1341,6 @@ public:
         register_container<TTContainer<T>>();
         return register_containers<T, TTRest...>();
     }
-    #endif
 
     operator formats() const
     {
@@ -1456,13 +1449,11 @@ formats_builder& formats_builder_dsl::register_container()
     return owner->register_container<TContainer>();
 }
 
-#if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
 template <typename T, template <class...> class... TTContainers>
 formats_builder& formats_builder_dsl::register_containers()
 {
     return owner->register_containers<T, TTContainers...>();
 }
-#endif
 
 template <typename TWrapper>
 formats_builder& formats_builder_dsl::register_wrapper()

--- a/include/jsonv/value.hpp
+++ b/include/jsonv/value.hpp
@@ -981,7 +981,7 @@ JSONV_PUBLIC extern const value null;
  *  })"_json;
  *  \endcode
 **/
-JSONV_PUBLIC value operator"" _json(const char* str, std::size_t len);
+JSONV_PUBLIC value operator""_json(const char* str, std::size_t len);
 
 /** Swap the values \a a and \a b. **/
 JSONV_PUBLIC void swap(value& a, value& b) noexcept;

--- a/src/jsonv-tests/object_tests.cpp
+++ b/src/jsonv-tests/object_tests.cpp
@@ -131,7 +131,7 @@ TEST(object_view)
 {
     const jsonv::value obj1 = jsonv::object({ { "foo", 5 }, { "bar", "wat" } });
     jsonv::value obj2 = jsonv::object();
-    for (const std::pair<const std::string, const jsonv::value>& entry : obj1.as_object())
+    for (const auto& entry : obj1.as_object())
         obj2.insert(entry);
     ensure_eq(obj1, obj2);
 }

--- a/src/jsonv-tests/serialization_builder_tests.cpp
+++ b/src/jsonv-tests/serialization_builder_tests.cpp
@@ -139,12 +139,7 @@ TEST(serialization_builder_container_members)
                         .member("age",              &person::age)
                         .member("favorite_numbers", &person::favorite_numbers)
                         .member("winning_numbers",  &person::winning_numbers)
-                    #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
                     .register_containers<long, std::set, std::vector>()
-                    #else
-                    .register_container<std::set<long>>()
-                    .register_container<std::vector<long>>()
-                    #endif
                     .compose_checked(formats::defaults())
                 ;
 
@@ -262,12 +257,7 @@ TEST(serialization_builder_defaults)
                                            }
                                           )
                             .default_on_null()
-                    #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
                     .register_containers<long, std::set, std::vector>()
-                    #else
-                    .register_container<std::set<long>>()
-                    .register_container<std::vector<long>>()
-                    #endif
                     .compose_checked(formats::defaults())
                 ;
 
@@ -295,12 +285,7 @@ TEST(serialization_builder_encode_checks)
                             .encode_if([] (const serialization_context&, const std::set<long>& nums) { return nums.size(); })
                         .member("winning_numbers",  &person::winning_numbers)
                             .encode_if([] (const serialization_context&, const std::vector<long>& nums) { return nums.size(); })
-                    #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
                     .register_containers<long, std::set, std::vector>()
-                    #else
-                    .register_container<std::set<long>>()
-                    .register_container<std::vector<long>>()
-                    #endif
                     .compose_checked(formats::list { formats::defaults() })
                 ;
 
@@ -512,11 +497,7 @@ TEST(serialization_builder_enum_strings)
                                { ring::heart, "heart" },
                              }
                             )
-            #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
             .register_containers<ring, std::vector>()
-            #else
-            .register_container<std::vector<ring>>()
-            #endif
             .check_references();
 
     ensure(ring::fire  == jsonv::extract<ring>("fire",  formats));
@@ -552,11 +533,7 @@ TEST(serialization_builder_enum_strings_icase)
                                { ring::heart, "heart" },
                              }
                             )
-            #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
             .register_containers<ring, std::vector>()
-            #else
-            .register_container<std::vector<ring>>()
-            #endif
             .check_references(jsonv::formats::defaults());
 
     ensure(ring::fire  == jsonv::extract<ring>("fiRe",  formats));
@@ -594,11 +571,7 @@ TEST(serialization_builder_enum_strings_icase_multimapping)
                                { ring::heart, "useless" },
                              }
                             )
-             #if JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES
-             .register_containers<ring, std::vector>()
-             #else
-             .register_container<std::vector<ring>>()
-             #endif
+            .register_containers<ring, std::vector>()
             .check_references(jsonv::formats::defaults());
 
     ensure(ring::fire  == jsonv::extract<ring>("fiRe",  formats));

--- a/src/jsonv-tests/value_tests.cpp
+++ b/src/jsonv-tests/value_tests.cpp
@@ -22,7 +22,8 @@ TEST(move_to_self)
     const jsonv::value orig = jsonv::object({ {"a", 5} });
     jsonv::value x(orig);
     ensure_eq(orig, x);
-    x = std::move(x);
+    jsonv::value& same = x;
+    x = std::move(same);
     ensure_eq(orig, x);
 }
 

--- a/src/jsonv/char_convert.cpp
+++ b/src/jsonv/char_convert.cpp
@@ -25,13 +25,9 @@
 #include "detail/fixed_map.hpp"
 #include "detail/is_print.hpp"
 
-#if __cplusplus >= 201703L || defined __has_include
-#   if __has_include(<alloca.h>)
-#       define JSONV_HAS_ALLOCA 1
-#       include <alloca.h>
-#   else
-#       define JSONV_HAS_ALLOCA 0
-#   endif
+#if __has_include(<alloca.h>)
+#   define JSONV_HAS_ALLOCA 1
+#   include <alloca.h>
 #else
 #   define JSONV_HAS_ALLOCA 0
 #endif

--- a/src/jsonv/detail/fallthrough.hpp
+++ b/src/jsonv/detail/fallthrough.hpp
@@ -17,17 +17,7 @@ namespace jsonv
 /// \def JSONV_FALLTHROUGH
 /// Used in \c case statements that are intentionally meant to fall through to the next.
 #ifndef JSONV_FALLTHROUGH
-#   if defined __has_cpp_attribute
-#       if __has_cpp_attribute(fallthrough)
-#           define JSONV_FALLTHROUGH() [[fallthrough]]
-#       elif __has_cpp_attribute(clang::fallthrough)
-#           define JSONV_FALLTHROUGH() [[clang::fallthrough]]
-#       else
-#           define JSONV_FALLTHROUGH()
-#       endif
-#   else
-#       define JSONV_FALLTHROUGH()
-#   endif
+#   define JSONV_FALLTHROUGH() [[fallthrough]]
 #endif
 
 }

--- a/src/jsonv/parse.cpp
+++ b/src/jsonv/parse.cpp
@@ -160,7 +160,7 @@ value parse(const char* begin, const char* end, const parse_options& parse_opts,
 
 JSONV_PARSE_IMPL_OVERLOADS((const char* begin, const char* end), (begin, end))
 
-value operator"" _json(const char* str, std::size_t len)
+value operator""_json(const char* str, std::size_t len)
 {
     return parse(string_view(str, len));
 }


### PR DESCRIPTION
JSON Voorhees 2.0 now targets C++23 as the minimum standard. Remove compatibility gates that only existed for older compilers and language modes.

Build and configuration:
- Require CMake 3.20 so CXX_STANDARD 23 is available.
- Set the project C++ standard with CMake target machinery.
- Keep warning flags separate from language mode flags.

Headers and implementation:
- Define JSONV_UNUSED, JSONV_NO_RETURN, JSONV_LIKELY, and JSONV_UNLIKELY directly with standard attributes.
- Define JSONV_FALLTHROUGH directly as [[fallthrough]].
- Remove JSONV_COMPILER_SUPPORTS_TEMPLATE_TEMPLATES and all uses.
- Always expose register_containers and simplify its tests.
- Simplify the alloca include check now that __has_include exists.

C++23 warning cleanup:
- Use the no-space operator""_json spelling.
- Replace deprecated aligned_storage in extraction helpers.
- Clean two test warning triggers found by the C++23 build.

Documentation:
- Update the README to state the C++23 compiler requirement.
- Treat compiler versions as examples, not as a fixed support matrix.
- Mark MSVC /std:c++23preview as experimental.