### PR TITLE
Add link-time optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,12 +78,41 @@ option(BENCHMARK
        OFF
       )
 
+# Link-time optimization gives the compiler a chance to inline across translation units, which
+# matters most for the parser hot path (parse_index.cpp + match/string.cpp + match/number.cpp).
+# Default ON for Release builds, OFF otherwise.
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(JSONV_LTO_DEFAULT ON)
+else()
+    set(JSONV_LTO_DEFAULT OFF)
+endif()
+option(JSONV_LTO
+       "Enable link-time / interprocedural optimization."
+       ${JSONV_LTO_DEFAULT}
+      )
+if(JSONV_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT JSONV_LTO_SUPPORTED OUTPUT JSONV_LTO_CHECK_OUTPUT)
+    if(JSONV_LTO_SUPPORTED)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(WARNING "JSONV_LTO requested but the toolchain does not support it: ${JSONV_LTO_CHECK_OUTPUT}")
+    endif()
+endif()
+
+option(JSONV_RELEASE_WITH_DEBUG_SYMBOLS
+       "Include debug symbols (-ggdb) in Release builds."
+       OFF
+      )
+
 if(WIN32)
 else(WIN32)
     # Reasonable compilers...
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG}   -ggdb -DJSONV_DEBUG=1")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ggdb")
+    if(JSONV_RELEASE_WITH_DEBUG_SYMBOLS)
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ggdb")
+    endif()
 endif(WIN32)
 
 include_directories("${PROJECT_SOURCE_DIR}/include"

--- a/scripts/perf-bench.sh
+++ b/scripts/perf-bench.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Build Release, run parse_index benchmarks, print a table with means.
+#
+# Usage:
+#   scripts/perf-bench.sh                # one trial per input
+#   scripts/perf-bench.sh -n 3           # three trials per input (medians shown)
+#   scripts/perf-bench.sh -f canada      # restrict to inputs whose filename contains 'canada'
+#
+# Notes:
+#   - canada.json (2.2 MB) is the only input large enough for stable numbers at the
+#     default 100 iterations baked into the test runner. Smaller inputs swing by
+#     2x+ between trials at the microsecond scale; treat them as smoke tests, not
+#     measurements.
+#   - The "parse_index/" rows time stage 1 alone (tape build). The "string/" and
+#     "ifstream/" rows time the full parse() including extract to jsonv::value.
+#     parse_index is only ~11% of full parse() on canada.json — see
+#     .agents/perf-baseline.txt for context.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+trials=1
+filter=""
+while getopts "n:f:h" opt; do
+    case "$opt" in
+        n) trials="$OPTARG" ;;
+        f) filter="$OPTARG" ;;
+        h)
+            sed -n '2,/^set -euo/p' "$0" | sed -n '/^#/p'
+            exit 0
+            ;;
+        *) exit 2 ;;
+    esac
+done
+
+if [ ! -x build/jsonv-tests ]; then
+    echo "Configuring Release build..." >&2
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DJSONV_BUILD_TESTS=ON >/dev/null
+fi
+cmake --build build -j --target jsonv-tests >/dev/null
+
+filter_arg="benchmark/parse_index/"
+if [ -n "$filter" ]; then
+    filter_arg="benchmark/parse_index/${filter}"
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+for ((t=1; t<=trials; t++)); do
+    ./build/jsonv-tests "$filter_arg" \
+        | awk -F'"' '
+            /benchmark\// {
+                # benchmark name is the token after "TEST: "
+                match($0, /benchmark\/[^ ]+/)
+                name = substr($0, RSTART, RLENGTH)
+                # $10 is the mean ISO8601 duration: "PT0.001791089S"
+                # ($1=prefix, $2=total, $3=:, $4=duration, $5=,, $6=count, $7=:N,, $8=mean, $9=:, $10=duration)
+                print name, $10
+            }
+          ' \
+        >> "$tmp"
+done
+
+# Aggregate: median (or only value) per benchmark name.
+awk '
+{
+    name=$1
+    # "PT0.001791089S" → 1.791089 ms
+    val=$2
+    sub(/^PT/, "", val); sub(/S$/, "", val)
+    seconds = val + 0
+    ms = seconds * 1000.0
+    n[name]++
+    times[name, n[name]] = ms
+}
+END {
+    for (name in n) {
+        cnt = n[name]
+        # Sort the times for this name (small N; insertion sort).
+        for (i = 1; i <= cnt; i++) {
+            sorted[i] = times[name, i]
+        }
+        for (i = 2; i <= cnt; i++) {
+            key = sorted[i]; j = i - 1
+            while (j >= 1 && sorted[j] > key) { sorted[j+1] = sorted[j]; j-- }
+            sorted[j+1] = key
+        }
+        median = (cnt % 2 == 1) ? sorted[(cnt+1)/2] : (sorted[cnt/2] + sorted[cnt/2+1]) / 2.0
+        spread = sorted[cnt] - sorted[1]
+        printf "%-50s  median=%9.4f ms  spread=%8.4f ms  (n=%d)\n", name, median, spread, cnt
+    }
+}
+' "$tmp" | sort

--- a/src/jsonv-tests/benchmark_tests.cpp
+++ b/src/jsonv-tests/benchmark_tests.cpp
@@ -15,6 +15,7 @@
 
 #include <jsonv/algorithm.hpp>
 #include <jsonv/parse.hpp>
+#include <jsonv/parse_index.hpp>
 #include <jsonv/value.hpp>
 
 #include <fstream>
@@ -38,6 +39,27 @@ static void run_test(FLoader load, const std::string& from)
             JSONV_TEST_TIME(timer);
             parse(src_data);
         }
+    }
+    std::cout << timer.get();
+}
+
+// Times stage-1 only: parse_index::parse on a string source. Skips the extract phase
+// (jsonv::value materialization), so the number reflects the parse_index hot path alone.
+static void run_parse_index_test(const std::string& path)
+{
+    std::ifstream inputfile(path.c_str());
+    std::string src;
+    inputfile.seekg(0, std::ios::end);
+    src.reserve(inputfile.tellg());
+    inputfile.seekg(0, std::ios::beg);
+    src.assign(std::istreambuf_iterator<char>(inputfile), std::istreambuf_iterator<char>());
+
+    stopwatch timer;
+    for (unsigned cnt = 0; cnt < iterations; ++cnt)
+    {
+        JSONV_TEST_TIME(timer);
+        auto idx = parse_index::parse(src);
+        (void)idx;
     }
     std::cout << timer.get();
 }
@@ -66,6 +88,24 @@ private:
     std::string path;
 };
 
+class parse_index_benchmark_test :
+        public unit_test
+{
+public:
+    explicit parse_index_benchmark_test(std::string path) :
+            unit_test(std::string("benchmark/parse_index/") + filename(path)),
+            path(std::move(path))
+    { }
+
+    virtual void run_impl() override
+    {
+        run_parse_index_test(path);
+    }
+
+private:
+    std::string path;
+};
+
 class benchmark_test_initializer
 {
 public:
@@ -81,6 +121,7 @@ public:
                                                                      )
                                    );
                 _tests.emplace_back(new benchmark_test<std::string>(load_from_file, "string", path));
+                _tests.emplace_back(new parse_index_benchmark_test(path));
             }
         });
     }

--- a/src/jsonv/detail/architecture.hpp
+++ b/src/jsonv/detail/architecture.hpp
@@ -1,0 +1,19 @@
+/// \file
+///
+/// Copyright (c) 2026 by Travis Gockel. All rights reserved.
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
+/// as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
+/// version.
+///
+/// \author Travis Gockel (travis@gockelhut.com)
+
+#include <jsonv/config.hpp>
+
+#ifndef JSONV_SSE2
+#   if defined __SSE2__ && __SSE2__
+#       define JSONV_SSE2 1
+#   else
+#       define JSONV_SSE2 0
+#   endif
+#endif

--- a/src/jsonv/detail/match/string.cpp
+++ b/src/jsonv/detail/match/string.cpp
@@ -156,6 +156,7 @@ match_string_result match_string(const char* iter, const char* end, const parse_
         }
         else if (!(*iter & '\x80'))
         {
+            JSONV_LIKELY
             if (check_printability && !is_print(*iter))
             {
                 JSONV_UNLIKELY

--- a/src/jsonv/parse_index.cpp
+++ b/src/jsonv/parse_index.cpp
@@ -1,6 +1,6 @@
 /// \file
 ///
-/// Copyright (c) 2020 by Travis Gockel. All rights reserved.
+/// Copyright (c) 2020-2026 by Travis Gockel. All rights reserved.
 ///
 /// This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
 /// as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
@@ -12,16 +12,22 @@
 #include <jsonv/serialization.hpp>
 
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <new>
 #include <sstream>
 #include <utility>
 
+#include "detail/architecture.hpp"
 #include "detail/fallthrough.hpp"
 #include "detail/match/number.hpp"
 #include "detail/match/string.hpp"
 #include "detail/overload.hpp"
+
+#if JSONV_SSE2
+#   include <emmintrin.h>
+#endif
 
 namespace jsonv
 {
@@ -159,13 +165,12 @@ struct JSONV_LOCAL parse_index::impl final
         // NOTE: Doubling the data capacity will always grow enough to hold a complete code size, as the minimum size
         // can hold the largest code size.
         auto new_capacity = self->data_capacity * 2;
+        auto new_alloc_sz = sizeof(impl) + new_capacity * sizeof(std::uint64_t);
 
-        // OPTIMIZATION: It's possible that `realloc` would be better here, but there is not an aligned version of that.
-        auto new_self = allocate(new_capacity);
-        std::memcpy(new_self, self, sizeof *new_self + self->data_size * sizeof self->data(0));
+        auto new_self = static_cast<impl*>(std::realloc(self, new_alloc_sz));
+        if (!new_self)
+            throw std::bad_alloc();
         new_self->data_capacity = new_capacity;
-
-        destroy(self);
         self = new_self;
     }
 
@@ -211,17 +216,44 @@ struct JSONV_LOCAL parse_index::impl final
                              );
 };
 
-// OPTIMIZATION(SIMD-SSE4.2): Skip over chunks with cmpistri
+static inline bool is_json_whitespace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
 static void fastforward_whitespace(const char*& iter, const char* end)
 {
-    while (iter < end)
+#if JSONV_SSE2
+    // 16-byte chunk scan: build a mask of whitespace bytes and find the first non-whitespace.
+    // Skip the SIMD path for very short remaining inputs; the tail loop is cheaper.
+    const __m128i ws_space = _mm_set1_epi8(' ');
+    const __m128i ws_tab   = _mm_set1_epi8('\t');
+    const __m128i ws_lf    = _mm_set1_epi8('\n');
+    const __m128i ws_cr    = _mm_set1_epi8('\r');
+
+    while (iter + 16 <= end)
     {
-        char c = *iter;
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
-            ++iter;
+        __m128i chunk = _mm_loadu_si128(reinterpret_cast<const __m128i*>(iter));
+        __m128i is_ws = _mm_or_si128(
+            _mm_or_si128(_mm_cmpeq_epi8(chunk, ws_space), _mm_cmpeq_epi8(chunk, ws_tab)),
+            _mm_or_si128(_mm_cmpeq_epi8(chunk, ws_lf),    _mm_cmpeq_epi8(chunk, ws_cr))
+        );
+        unsigned ws_mask = static_cast<unsigned>(_mm_movemask_epi8(is_ws));
+        unsigned non_ws  = (~ws_mask) & 0xFFFFu;
+        if (non_ws == 0u)
+        {
+            iter += 16;
+        }
         else
-            break;
+        {
+            iter += __builtin_ctz(non_ws);
+            return;
+        }
     }
+#endif
+
+    while (iter < end && is_json_whitespace(*iter))
+        ++iter;
 }
 
 static bool fastforward_comment(const char*& ext_iter, const char* end)
@@ -248,7 +280,6 @@ static bool fastforward_comment(const char*& ext_iter, const char* end)
     return false;
 }
 
-// OPTIMIZATION(SIMD): Tokens can be checked as a single `uint32_t`, including "false", as 'f' has already been checked.
 template <std::size_t NPlusOne>
 void parse_index::impl::parse_literal(impl*&        self,
                                       const char*   begin,
@@ -259,17 +290,27 @@ void parse_index::impl::parse_literal(impl*&        self,
                                      )
 {
     static constexpr std::size_t N = NPlusOne - 1;
+    static_assert(N == 4 || N == 5, "parse_literal is specialized for true/false/null only");
 
     if (iter + N <= end)
     {
-        // start at `idx` 1 because `parse` checks the first value
-        for (std::size_t idx = 1; idx < N; ++idx)
+        // Compare the literal as a single 4-byte word (covers "true"/"null" entirely, and the
+        // first four bytes of "false"). The dispatching switch in parse() has already verified
+        // the first byte, but including it costs nothing and lets the compiler emit a single
+        // 32-bit compare with a constant.
+        std::uint32_t observed;
+        std::uint32_t expected;
+        std::memcpy(&observed, iter, 4);
+        std::memcpy(&expected, expected_token, 4);
+
+        bool ok = (observed == expected);
+        if constexpr (N == 5)
+            ok = ok && (iter[4] == expected_token[4]);
+
+        if (!ok)
         {
-            if (iter[idx] != expected_token[idx])
-            {
-                JSONV_UNLIKELY
-                throw push_error(*&self, ast_error::invalid_literal, begin, iter);
-            }
+            JSONV_UNLIKELY
+            throw push_error(*&self, ast_error::invalid_literal, begin, iter);
         }
 
         push_back(self, success_value, iter);
@@ -601,8 +642,12 @@ parse_index parse_index::parse(string_view           src,
                                optional<std::size_t> initial_buffer_capacity
                               )
 {
-    // OPTIMIZATION: Better heuristics on initial buffer capacity.
-    auto p       = impl::allocate(initial_buffer_capacity.value_or(src.size() / 16));
+    // Initial capacity in tape slots (8 bytes each). The right ratio depends on input shape:
+    // a pure-strings document needs near-zero slots/byte; a boolean-array worst-case needs ~0.6.
+    // Empirical density on canada.json is ~0.4 slots/byte, so `/ 3` covers most realistic inputs
+    // with at most one realloc. Over-allocation cost is mostly RAM commit; under-allocation cost
+    // (since grow_data_buffer now uses realloc) is one move-only realloc per doubling.
+    auto p       = impl::allocate(initial_buffer_capacity.value_or(src.size() / 3));
     p->src_begin = src.data();
 
     try


### PR DESCRIPTION
You can now specify `JSONV_LTO` to add link-time optimization on platforms it is supported on. Additionally, the CMake option `JSONV_RELEASE_WITH_DEBUG_SYMBOLS` enables debug symbols on release targets (previously, you could only do this when the `CMAKE_BUILD_TYPE == "RelWithDebInfo"`.