### PR TITLE
Make JSON decimal representations more round-trip stable

### DIFF
--- a/src/jsonv-tests/encode_tests.cpp
+++ b/src/jsonv-tests/encode_tests.cpp
@@ -18,9 +18,20 @@
 #include <iostream>
 #include <locale>
 #include <sstream>
+#include <string_view>
 
 namespace jsonv_test
 {
+
+namespace
+{
+
+void ensure_encodes_as(std::string_view input, std::string_view expected)
+{
+    ensure_eq(std::string(expected), jsonv::to_string(jsonv::parse(input)));
+}
+
+}
 
 static const char k_some_json[] = R"({
   "a": [ 4, 5, 6, [7, 8, 9, {"something": 5, "else": 6}]],
@@ -53,6 +64,14 @@ TEST(encode_nan)
     // change val to have null in place of the NaN
     val.at_path(".a[2]") = jsonv::null;
     ensure_eq(val, decoded);
+}
+
+TEST(encode_decimal_shortest_roundtrip)
+{
+    ensure_encodes_as("[5e-324]", "[5e-324]");
+    ensure_encodes_as("[2.225073858507201e-308]", "[2.225073858507201e-308]");
+    ensure_encodes_as("[2.2250738585072014e-308]", "[2.2250738585072014e-308]");
+    ensure_encodes_as("[1.7976931348623157e308]", "[1.7976931348623157e+308]");
 }
 
 TEST(encode_invalid_utf8_uses_replacement_for_bogus_2_byte)

--- a/src/jsonv-tests/parse_tests.cpp
+++ b/src/jsonv-tests/parse_tests.cpp
@@ -11,7 +11,9 @@
 
 #include <jsonv/parse.hpp>
 
+#include <cmath>
 #include <iostream>
+#include <stdexcept>
 
 using namespace jsonv;
 
@@ -42,6 +44,34 @@ TEST_PARSE(number_negative_double_zero)
 TEST_PARSE(number_leading_zero)
 {
     ensure_throws(parse_error, parse("013"));
+}
+
+TEST_PARSE(number_decimal_underflow)
+{
+    value result = parse("[1e-10000]");
+    auto parsed = result.at(0).as_decimal();
+    ensure_eq(0.0, parsed);
+    ensure(!std::signbit(parsed));
+}
+
+TEST_PARSE(number_decimal_underflow_large_exponents)
+{
+    value result = parse("[1e-214748363, 1e-214748364]");
+    ensure_eq(0.0, result.at(0).as_decimal());
+    ensure_eq(0.0, result.at(1).as_decimal());
+}
+
+TEST_PARSE(number_decimal_negative_underflow)
+{
+    value result = parse("[-1e-10000]");
+    auto parsed = result.at(0).as_decimal();
+    ensure_eq(0.0, parsed);
+    ensure(std::signbit(parsed));
+}
+
+TEST_PARSE(number_decimal_overflow_still_throws)
+{
+    ensure_throws(std::invalid_argument, parse("[1e10000]"));
 }
 
 static const value simple_obj = object({ { "foo", 4 },

--- a/src/jsonv/ast.cpp
+++ b/src/jsonv/ast.cpp
@@ -204,7 +204,11 @@ double ast_node::decimal::value() const
     // need to enable hex / infinity / nan parsing.
     double val{};
     auto result = fast_float::from_chars(begin, end, val, fast_float::chars_format::general);
-    if (result.ec == std::errc{} && result.ptr == end)
+    if (  result.ptr == end
+       && (  result.ec == std::errc{}
+          || (result.ec == std::errc::result_out_of_range && val == 0.0)
+          )
+       )
         return val;
     else
         throw make_failed_numeric_extract(*this, "decimal");

--- a/src/jsonv/encode.cpp
+++ b/src/jsonv/encode.cpp
@@ -14,8 +14,11 @@
 
 #include "detail.hpp"
 
+#include <array>
+#include <charconv>
 #include <cmath>
 #include <ostream>
+#include <system_error>
 
 namespace jsonv
 {
@@ -114,7 +117,17 @@ void ostream_encoder::write_boolean(bool value)
 void ostream_encoder::write_decimal(double value)
 {
     if (std::isfinite(value))
-        _output << value;
+    {
+        std::array<char, 64> buffer;
+        auto result = std::to_chars(buffer.data(),
+                                    buffer.data() + buffer.size(),
+                                    value,
+                                    std::chars_format::general);
+        if (result.ec == std::errc{})
+            _output.write(buffer.data(), result.ptr - buffer.data());
+        else
+            _output << value;
+    }
     else
         // non-finite values do not have valid JSON representations, so put it as null
         write_null();


### PR DESCRIPTION
This fixes issue #74 and makes JSON decimal outputs more precise (when we have the bits) and treat exponent underflow going to 0 as not an error.