### PR TITLE
Make value equality reflexive for corrupt kinds

### DIFF
--- a/include/jsonv/value.hpp
+++ b/include/jsonv/value.hpp
@@ -593,12 +593,13 @@ public:
     /** Swap the value this instance represents with \a other. **/
     void swap(value& other) noexcept;
 
-    /** Compares two JSON values for equality. Two JSON values are equal if and only if all of the following conditions
-     *  apply:
+    /** Compares two JSON values for equality. Two JSON values are equal if and only if they refer
+     *  to the same object \e or all of the following conditions apply:
      *
      *   1. They have the same valid value for \c kind.
-     *      - If \c kind is invalid (memory corruption), then two JSON values are \e not equal, even if they have been
-     *        corrupted in the same way and even if they share \c this (a corrupt object is not equal to itself).
+     *      - If either side has an invalid \c kind (memory corruption), the two distinct values
+     *        compare unequal. A value always compares equal to itself, even if its \c kind has
+     *        been corrupted -- equality is reflexive.
      *   2. The kind comparison is also equal:
      *      - Two null values are always equivalent.
      *      - string, integer, decimal and boolean follow the classic rules for their type.

--- a/src/jsonv-tests/value_tests.cpp
+++ b/src/jsonv-tests/value_tests.cpp
@@ -13,6 +13,7 @@
 #include <jsonv/all.hpp>
 
 #include <cstdint>
+#include <cstring>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -145,4 +146,44 @@ TEST(hash_set_operations)
     set.erase(str);
     ensure_eq(0U, set.count(str));
     ensure_eq(5U, set.size());
+}
+
+/// Regression for the equality-reflexivity bug: a `value` whose `kind` byte has been corrupted
+/// (e.g. via uninitialized memory or a wild write) must still satisfy `x == x`. Standard
+/// containers and the library's own `std::hash<value>` rely on `EqualityComparable`, so a
+/// non-reflexive `operator==` is a soundness hazard rather than a graceful degradation.
+TEST(equality_is_reflexive_for_corrupt_kind)
+{
+    // Start from a default-constructed (null) value, which owns no heap resources. Scribbling
+    // its `kind` byte therefore can't leak anything.
+    jsonv::value v;
+
+    unsigned char snapshot[sizeof(jsonv::value)];
+    std::memcpy(snapshot, &v, sizeof v);
+
+    unsigned char corrupted[sizeof(jsonv::value)];
+    std::memcpy(corrupted, snapshot, sizeof v);
+    // The 8-byte `_data` union sits at offset 0 (it's a default-constructed null, so all
+    // its bytes are zero); the `_kind` byte lives somewhere in the trailing padding region.
+    // Scribbling 0xFF over every byte past offset 8 forces `_kind` to an invalid value
+    // without disturbing the (already-null) storage union.
+    for (std::size_t i = 8; i < sizeof v; ++i)
+        corrupted[i] = 0xFF;
+    std::memcpy(&v, corrupted, sizeof v);
+
+    // The kind is now invalid -- but reflexivity must hold.
+    ensure(v == v);
+    ensure(!(v != v));
+    ensure_eq(0, v.compare(v));
+
+    // Two *distinct* values where one is corrupt still compare unequal, and we must not
+    // assert or throw doing so.
+    jsonv::value good = 42;
+    ensure(v != good);
+    ensure(good != v);
+    ensure(!(v == good));
+    ensure(!(good == v));
+
+    // Restore so the destructor sees a well-formed null.
+    std::memcpy(&v, snapshot, sizeof v);
 }

--- a/src/jsonv/value.cpp
+++ b/src/jsonv/value.cpp
@@ -406,7 +406,11 @@ bool value::as_boolean() const
 
 bool value::operator==(const value& other) const
 {
-    if (this == &other && kind_valid(kind()))
+    // Reflexive even when `_kind` has been corrupted: `x == x` must hold so that `value` satisfies
+    // the EqualityComparable requirements that `std::hash<value>` and standard containers rely on.
+    // For distinct objects, `compare` already treats invalid kinds as a kind-sentinel and orders
+    // them, so they compare unequal to any well-formed value without asserting or throwing.
+    if (this == &other)
         return true;
     else
         return compare(other) == 0;
@@ -414,10 +418,7 @@ bool value::operator==(const value& other) const
 
 bool value::operator !=(const value& other) const
 {
-    // must be first: an invalid type is not equal to itself
-    if (!kind_valid(kind()))
-        return true;
-
+    // Mirror of `operator==` -- reflexivity is unconditional, even for corrupt `_kind`.
     if (this == &other)
         return false;
     else


### PR DESCRIPTION
`value::operator==` and `operator!=` previously violated reflexivity when `_kind` was corrupt: `x == x` returned false and `x != x` returned true for any value whose kind byte had been scribbled (e.g. via an uninitialized read or wild write). That break in `EqualityComparable` silently undermines `std::hash<value>` -- which the library exports -- and any standard container that holds a `value`.

The "many corruption checks" rationale only required that `==` not assert or throw on a corrupt kind. It did not require non-reflexivity, which is a strictly worse failure mode (containers go quietly wrong instead of loudly wrong). Drop the `kind_valid` check on the self- comparison fast paths so identity always wins. For distinct values, the existing `compare` machinery already maps invalid kinds to a sentinel (`compare_traits::kindval` returns -1) and orders them away from any well-formed value, so we still degrade gracefully without throwing.

Update the doc comment in `value.hpp`, which previously promised the broken behavior, and add a regression test that scribbles the kind byte of a default-constructed null and verifies reflexivity for `==`, `!=`, and `compare`, plus sane (non-throwing) ordering against a well-formed value.